### PR TITLE
Fix crash when mapping on networks with unresolved boundary lines

### DIFF
--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigCsvWriter.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigCsvWriter.java
@@ -97,8 +97,6 @@ public class TimeSeriesMappingConfigCsvWriter implements TimeSeriesConstants {
     private static final String MAX_POWER = "MaxPower";
     private static final String AVERAGE_POWER = "AveragePower";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TimeSeriesMappingConfigCsvWriter.class);
-
     private static final List<String> GENERATOR_HEADER = Collections.unmodifiableList(Lists.newArrayList(
             SUBSTATION,
             VOLTAGE_LEVEL,
@@ -324,6 +322,7 @@ public class TimeSeriesMappingConfigCsvWriter implements TimeSeriesConstants {
                 case PST_TYPE:
                 case BREAKER_TYPE:
                 case EMPTY_TYPE:
+                case BOUNDARY_LINE:
                     writer.write(equipmentType);
                     writer.write(CSV_SEPARATOR);
                     break;
@@ -333,7 +332,6 @@ public class TimeSeriesMappingConfigCsvWriter implements TimeSeriesConstants {
                 case HVDC_LINES:
                 case PSTS:
                 case BREAKERS:
-                case BOUNDARY_LINE:
                     break;
 
                 default:

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigCsvWriter.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigCsvWriter.java
@@ -20,6 +20,8 @@ import com.powsybl.iidm.network.extensions.LoadDetail;
 import com.powsybl.iidm.network.extensions.LoadDetailAdder;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
 import com.powsybl.timeseries.TimeSeriesFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -94,6 +96,8 @@ public class TimeSeriesMappingConfigCsvWriter implements TimeSeriesConstants {
     private static final String MIN_POWER = "MinPower";
     private static final String MAX_POWER = "MaxPower";
     private static final String AVERAGE_POWER = "AveragePower";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimeSeriesMappingConfigCsvWriter.class);
 
     private static final List<String> GENERATOR_HEADER = Collections.unmodifiableList(Lists.newArrayList(
             SUBSTATION,
@@ -329,6 +333,7 @@ public class TimeSeriesMappingConfigCsvWriter implements TimeSeriesConstants {
                 case HVDC_LINES:
                 case PSTS:
                 case BREAKERS:
+                case BOUNDARY_LINE:
                     break;
 
                 default:

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigCsvWriter.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigCsvWriter.java
@@ -20,8 +20,6 @@ import com.powsybl.iidm.network.extensions.LoadDetail;
 import com.powsybl.iidm.network.extensions.LoadDetailAdder;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
 import com.powsybl.timeseries.TimeSeriesFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix a crash when mapping on a network that has boundary lines. When doing so, an exception gets thrown:
`
java.lang.AssertionError: Unsupported equipment type BoundaryLine
    at com.powsybl.metrix.mapping.TimeSeriesMappingConfigCsvWriter.writeEquipment
...
`
This fix allows the writer to take boundary lines into account when producing output.

**What is the current behavior?** *(You can also link to an open issue here)*
Crash when mapping on a network with boundary lines.

**What is the new behavior (if this is a feature change)?**
No more crash. Now boundary lines can be mapped like any other supported equipment.