### PR TITLE
[IMG-588] Alignment on directional thresholds

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/AbstractMetrix.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/AbstractMetrix.java
@@ -382,10 +382,9 @@ public abstract class AbstractMetrix {
         if (ratingTimeSeriesOrEx == ratingTimeSeriesExOr) {
             return createLoadTimeSeries(flowTimeSeries, ratingTimeSeriesOrEx);
         } else {
-            NodeCalc negativeRatingTimeSeries = UnaryOperation.negative(ratingTimeSeriesExOr);
             NodeCalc zero = new IntegerNodeCalc(0);
             NodeCalc ratingTimeSeries = BinaryOperation.plus(BinaryOperation.multiply(BinaryOperation.greaterThan(flowTimeSeries, zero), ratingTimeSeriesOrEx),
-                    BinaryOperation.multiply(BinaryOperation.lessThan(flowTimeSeries, zero), negativeRatingTimeSeries));
+                    BinaryOperation.multiply(BinaryOperation.lessThan(flowTimeSeries, zero), ratingTimeSeriesExOr));
             return createLoadTimeSeries(flowTimeSeries, ratingTimeSeries);
         }
     }

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixPostProcessingTimeSeriesTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixPostProcessingTimeSeriesTest.java
@@ -35,9 +35,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Created by marifunf on 02/05/17.
- */
 public class MetrixPostProcessingTimeSeriesTest {
 
     private FileSystem fileSystem;
@@ -152,7 +149,7 @@ public class MetrixPostProcessingTimeSeriesTest {
         NodeCalc ratingN2OrEx = new IntegerNodeCalc(1000);
         NodeCalc ratingN2ExOr = new TimeSeriesNameNodeCalc("tsNEndOr");
         NodeCalc ratingN2 = BinaryOperation.plus(BinaryOperation.multiply(BinaryOperation.greaterThan(flow2, new IntegerNodeCalc(0)), ratingN2OrEx),
-            BinaryOperation.multiply(BinaryOperation.lessThan(flow2, new IntegerNodeCalc(0)), UnaryOperation.negative(ratingN2ExOr)));
+            BinaryOperation.multiply(BinaryOperation.lessThan(flow2, new IntegerNodeCalc(0)), ratingN2ExOr));
         NodeCalc ratingNk2OrEx = new IntegerNodeCalc(2000);
         NodeCalc ratingNk2ExOr = new TimeSeriesNameNodeCalc("tsN1EndOr");
 


### PR DESCRIPTION
Signed-off-by: berthault <valentinberthault@outlook.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
When generating the load chronicles of the works in the METRIX postprocessings (basecaseLoad and OutageLoad) and the resulting summary statistics, the fact of using directional thresholds leads to having chronicles in absolute value.

This is not the case when there are no directional thresholds and this sign information is useful for analysis.

**What is the new behavior (if this is a feature change)?**
Keep the sign of the flow in the calculation of the basecaseLoad and outagaLoad chronicles.


