### PR TITLE
[IMG-432]add access to chronicles created in metrix configuration script

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/io/MetrixConfigResult.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/io/MetrixConfigResult.java
@@ -1,0 +1,48 @@
+package com.powsybl.metrix.integration.io;
+
+import com.powsybl.metrix.integration.MetrixDslData;
+import com.powsybl.timeseries.ast.NodeCalc;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class MetrixConfigResult {
+
+    private final MetrixDslData metrixDslData;
+
+    private final Map<String, NodeCalc> mappingTimeSeriesNodes = new HashMap<>();
+
+    private final Map<String, NodeCalc> metrixTimeSeriesNodes = new HashMap<>();
+
+    public MetrixDslData getMetrixDslData() {
+        return metrixDslData;
+    }
+
+    public Map<String, NodeCalc> getMappingTimeSeriesNodes() {
+        return mappingTimeSeriesNodes;
+    }
+
+    public Map<String, NodeCalc> getMetrixTimeSeriesNodes() {
+        return metrixTimeSeriesNodes;
+    }
+
+    public MetrixConfigResult(MetrixDslData metrixDslData, Map<String, NodeCalc> timeSeriesNodesAfterMapping, Map<String, NodeCalc> timeSeriesNodesAfterMetrix) {
+        Objects.requireNonNull(timeSeriesNodesAfterMapping);
+        Objects.requireNonNull(timeSeriesNodesAfterMetrix);
+        this.metrixDslData = metrixDslData;
+        List<String> overloadedTimeSeriesNames = timeSeriesNodesAfterMapping.keySet().stream()
+                .filter(timeSeriesNodesAfterMetrix::containsKey)
+                .filter(e -> timeSeriesNodesAfterMapping.get(e) != timeSeriesNodesAfterMetrix.get(e))
+                .collect(Collectors.toList());
+        // Remove from mapping nodes time series defined in mapping script and in metrix configuration script (same name but different formula)
+        // -> metrix one overloads mapping one
+        timeSeriesNodesAfterMapping.keySet().removeAll(overloadedTimeSeriesNames);
+        this.mappingTimeSeriesNodes.putAll(timeSeriesNodesAfterMapping);
+        // Remove from metrix nodes all mapping nodes
+        timeSeriesNodesAfterMetrix.keySet().removeAll(mappingTimeSeriesNodes.keySet());
+        this.metrixTimeSeriesNodes.putAll(timeSeriesNodesAfterMetrix);
+    }
+}

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixMock.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixMock.java
@@ -11,6 +11,7 @@ package com.powsybl.metrix.integration;
 import com.powsybl.commons.io.WorkingDirectory;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.contingency.ContingenciesProvider;
+import com.powsybl.metrix.integration.io.MetrixConfigResult;
 import com.powsybl.metrix.integration.io.ResultListener;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
 
@@ -27,7 +28,7 @@ public class MetrixMock extends AbstractMetrix {
                       Supplier<Reader> mappingReaderSupplier, Supplier<Reader> metrixDslReaderSupplier,
                       Supplier<Reader> remedialActionsReaderSupplier, ReadOnlyTimeSeriesStore store,
                       ReadOnlyTimeSeriesStore resultStore, ZipOutputStream logArchive, ComputationManager computationManager,
-                      MetrixAppLogger appLogger, Consumer<Future<?>> updateTask, Writer logWriter, Consumer<MetrixDslData> onResult) {
+                      MetrixAppLogger appLogger, Consumer<Future<?>> updateTask, Writer logWriter, Consumer<MetrixConfigResult> onResult) {
         super(networkSource, contingenciesProvider, mappingReaderSupplier, metrixDslReaderSupplier, remedialActionsReaderSupplier,
                 store, resultStore, logArchive, computationManager, appLogger, updateTask, logWriter, onResult);
     }

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixTest.java
@@ -18,6 +18,7 @@ import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.contingency.ContingenciesProvider;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.xml.NetworkXml;
+import com.powsybl.metrix.integration.io.MetrixConfigResult;
 import com.powsybl.metrix.integration.io.ResultListener;
 import com.powsybl.metrix.mapping.timeseries.InMemoryTimeSeriesStore;
 import com.powsybl.timeseries.InfiniteTimeSeriesIndex;
@@ -32,7 +33,6 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.zip.ZipOutputStream;
@@ -82,8 +82,7 @@ public class MetrixTest extends AbstractConverterTest {
                 return this;
             }
         };
-        AtomicReference<MetrixDslData> metrixDslDataResult = new AtomicReference<>();
-        Consumer<MetrixDslData> metrixDslDataConsumer = metrixDslDataResult::set;
+        Consumer<MetrixConfigResult> metrixDslDataConsumer = MetrixConfigResult::getMetrixTimeSeriesNodes;
         StringWriter logWriter = new StringWriter();
 
         Supplier<Reader> mappingReader = () -> new StringReader("");


### PR DESCRIPTION
Signed-off-by: berthault <valentinberthault@outlook.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If chronicles are created during the METRIX configuration, they cannot be retrieved in output


**What is the new behavior (if this is a feature change)?**
If chronicles are created during the METRIX configuration, they must be able to be retrieved on output.

