### PR TITLE
Add gmavenplus-plugin config in pom in order to generate javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,36 @@
             <build>
                 <plugins>
                     <plugin>
+                        <!-- This part was added in order to generate javadoc and groovydoc and deploy it.
+                          It was necessary to copy it from powsybl-parent since the line "<attach>true</attach>"
+                           has no parameter to configure it yet. It might be interesting to add a parameter  for
+                           this in powsybl-parent -->
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
+                        <version>${maven.gmavenplus.version}</version>
+                        <executions>
+                            <execution>
+                                <id>groovydoc-jar</id>
+                                <goals>
+                                    <goal>groovydoc-jar</goal>
+                                </goals>
+                                <configuration>
+                                    <attach>true</attach>
+                                    <includeClasspath>PROJECT_AND_PLUGIN</includeClasspath>
+                                    <classifier>${groovydoc.classifier}</classifier>
+                                    <groovyDocJavaSources>${groovydoc.groovyDocJavaSources}</groovyDocJavaSources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.codehaus.groovy</groupId>
+                                <artifactId>groovy-groovydoc</artifactId>
+                                <version>${maven.groovydoc.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Add gmavenplus-plugin config in pom in order to generate javadoc


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Groovydoc/javadoc is not generated nor sent to sonatype


**What is the new behavior (if this is a feature change)?**
doc is sent


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
