### PR TITLE
Changed SuiteSParse source for Devin

### DIFF
--- a/metrix-simulator/external/CMakeLists.txt
+++ b/metrix-simulator/external/CMakeLists.txt
@@ -32,15 +32,13 @@ include(ExternalProject)
 include(GetPatchCommand)
 include(CloneUrl)
 
-set(suitesparse_version  5.4.0)
-set(suitesparse_name     SuiteSparse-${suitesparse_version}.tar.gz)
-set(suitesparse_prefix_url http://faculty.cse.tamu.edu/davis/SuiteSparse)
-set(suitesparse_url      ${suitesparse_prefix_url}/${suitesparse_name})
-set(suitesparse_md5      4A6D4E74FC44C503F52996AE95CAD03A)
+set(suitesparse_url https://github.com/DrTimothyAldenDavis/SuiteSparse.git)
+set(suitesparse_tag_version v5.4.0)
 
-set(SUITESPARSE_HOME ${CMAKE_CURRENT_BINARY_DIR}/suitesparse)
-find_package(SuiteSparse QUIET)
-unset(SUITESPARSE_HOME)
+if(DEFINED ENV{NNI} AND DEFINED ENV{NNI_PASSWORD})
+  get_url(NAME suitesparse URL ${suitesparse_url} NNI $ENV{NNI} PASSWORD $ENV{NNI_PASSWORD})
+  set(suitesparse_url ${SUITEPARSE_URL})
+endif()
 
 GetPatchCommand(${CMAKE_CURRENT_SOURCE_DIR} suitesparse)
 if(SuiteSparse_FOUND)
@@ -49,13 +47,12 @@ if(SuiteSparse_FOUND)
 else()
   ExternalProject_Add(suitesparse
     INSTALL_DIR         ${CMAKE_CURRENT_BINARY_DIR}/suitesparse
-    DOWNLOAD_DIR        ${CMAKE_CURRENT_SOURCE_DIR}/suitesparse
     TMP_DIR             ${TMP_DIR}
     STAMP_DIR           ${DOWNLOAD_DIR}/suitesparse-stamp
     SOURCE_DIR          ${DOWNLOAD_DIR}/suitesparse
     BINARY_DIR          ${DOWNLOAD_DIR}/suitesparse-build
-    URL                 ${suitesparse_url}
-    URL_MD5             ${suitesparse_md5}
+    GIT_REPOSITORY      ${suitesparse_url}
+    GIT_TAG             refs/tags/${suitesparse_tag_version}
     PATCH_COMMAND       ${suitesparse_patch}
 
     CMAKE_CACHE_ARGS    -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
It changes the way the library SuiteSparse is downloaded.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
SuiteSparse was previously downloaded directly from its historical website.


**What is the new behavior (if this is a feature change)?**
SuiteSparse is now downloaded from its official Github repository.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
