### PR TITLE
Java:S6322: unsupported methods should not be called on some collection implementations

### DIFF
--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesStoreUtil.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesStoreUtil.java
@@ -123,7 +123,7 @@ public final class TimeSeriesStoreUtil {
 
         TimeSeriesTable table = new TimeSeriesTable(versions.first(), versions.last(), indexes.iterator().next(), byteBufferAllocator);
         for (int version : versions) {
-            List<DoubleTimeSeries> doubleTimeSeries = doubleTimeSeriesNames.isEmpty() ? Collections.emptyList()
+            List<DoubleTimeSeries> doubleTimeSeries = doubleTimeSeriesNames.isEmpty() ? new ArrayList<>()
                     : store.getDoubleTimeSeries(doubleTimeSeriesNames, version);
 
             // complete time series list to have the same list for each version
@@ -131,7 +131,7 @@ public final class TimeSeriesStoreUtil {
             missingDoubleTimeSeriesNames.removeAll(doubleTimeSeries.stream().map(ts -> ts.getMetadata().getName()).collect(Collectors.toList()));
             doubleTimeSeries.addAll(missingDoubleTimeSeriesNames.stream().map(name -> new StoredDoubleTimeSeries(metadataMap.get(name))).collect(Collectors.toList()));
 
-            List<StringTimeSeries> stringTimeSeries = stringTimeSeriesNames.isEmpty() ? Collections.emptyList()
+            List<StringTimeSeries> stringTimeSeries = stringTimeSeriesNames.isEmpty() ? new ArrayList<>()
                     : store.getStringTimeSeries(stringTimeSeriesNames, version);
 
             // complete time series list to have the same list for each version


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Quality

**What is the current behavior?**
Methods addAll may be called on Collections.emptyList() which is immutable

**What is the new behavior (if this is a feature change)?**
Collections.emptyList() replaced by new ArrayList<>()
