### PR TITLE
[IMG-2137] Mapping script handling with super class of TimeSeriesDslL…

### DIFF
--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixConstantVariantTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixConstantVariantTest.java
@@ -105,7 +105,7 @@ class MetrixConstantVariantTest {
 
         TimeSeriesMappingConfig mappingConfig;
         try (Reader mappingReader = new InputStreamReader(MetrixConstantVariantTest.class.getResourceAsStream("/inputs/constantVariantTestMappingInput.groovy"), StandardCharsets.UTF_8)) {
-            mappingConfig = TimeSeriesDslLoader.load(mappingReader, network, mappingParameters, store, new DataTableStore(), null, null);
+            mappingConfig = new TimeSeriesDslLoader(mappingReader).load(network, mappingParameters, store, new DataTableStore(), null, null);
         }
 
         MetrixDslData metrixDslData;

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderTest.java
@@ -87,7 +87,7 @@ class MetrixDslDataLoaderTest {
         }
 
         ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
 
         MetrixDslData data = MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig);
 
@@ -163,7 +163,7 @@ class MetrixDslDataLoaderTest {
         }
 
         ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
 
         MetrixDslData data = MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig);
 
@@ -272,7 +272,7 @@ class MetrixDslDataLoaderTest {
         }
 
         ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
         MetrixDslData data = MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig);
 
         assertEquals(13, data.getContingencyFlowResult("FP.AND1  FVERGE1  1").size());
@@ -304,7 +304,7 @@ class MetrixDslDataLoaderTest {
         }
 
         ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
         MetrixDslData data = MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig);
 
         assertNull(data.getPreventiveLoadCost("FVALDI11_L"));
@@ -427,7 +427,7 @@ class MetrixDslDataLoaderTest {
                 "}"));
         }
 
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile2, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile2).load(network, mappingParameters, store, new DataTableStore(), null);
 
         MetrixDslData data = MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig);
 
@@ -468,7 +468,7 @@ class MetrixDslDataLoaderTest {
                 "}"));
         }
 
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
 
         assertThrows(TimeSeriesMappingException.class,
             () -> MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig),
@@ -828,7 +828,7 @@ class MetrixDslDataLoaderTest {
                 "}"));
         }
 
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
         MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig);
 
         assertEquals(3, tsConfig.getEquipmentIds("tsN").size());
@@ -897,7 +897,7 @@ class MetrixDslDataLoaderTest {
                 "}"));
         }
 
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
         MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig);
 
         assertEquals(2, tsConfig.getEquipmentIds("tsN").size());
@@ -966,7 +966,7 @@ class MetrixDslDataLoaderTest {
         }
 
         ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
         MetrixDslData data = MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig);
 
         assertEquals(Integer.valueOf(3), data.getPtcLowerTapChange("FP.AND1  FTDPRA1  1"));
@@ -993,7 +993,7 @@ class MetrixDslDataLoaderTest {
         }
 
         ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
-        TimeSeriesMappingConfig tsConfig = TimeSeriesDslLoader.load(mappingFile, network, mappingParameters, store, new DataTableStore(), null);
+        TimeSeriesMappingConfig tsConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
         MetrixDslData data = MetrixDslDataLoader.load(dslFile, network, parameters, store, tsConfig);
 
         assertEquals(2, data.getBranchMonitoringNList().size());

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixExceptionTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixExceptionTest.java
@@ -21,6 +21,7 @@ import com.powsybl.metrix.integration.exceptions.MappingScriptLoadingException;
 import com.powsybl.metrix.integration.exceptions.MetrixScriptLoadingException;
 import com.powsybl.metrix.integration.metrix.MetrixAnalysis;
 import com.powsybl.metrix.integration.metrix.MetrixInputAnalysis;
+import com.powsybl.metrix.mapping.TimeSeriesDslLoader;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStoreCache;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,8 +97,9 @@ public class MetrixExceptionTest {
         NetworkXml.write(network, networkFile);
         NetworkSource networkSource = new DefaultNetworkSourceImpl(networkFile, computationManager);
         Reader mappingReader = Files.newBufferedReader(wrongDslFile, StandardCharsets.UTF_8);
-        MetrixAnalysis metrixAnalysis = new MetrixAnalysis(networkSource, mappingReader, null, null, null,
-            new ReadOnlyTimeSeriesStoreCache(), appLogger, null);
+        TimeSeriesDslLoader timeSeriesDslLoader = new TimeSeriesDslLoader(mappingReader);
+        MetrixAnalysis metrixAnalysis = new MetrixAnalysis(networkSource, timeSeriesDslLoader, null, null, null,
+                new ReadOnlyTimeSeriesStoreCache(), appLogger, null);
         assertThrows(MappingScriptLoadingException.class, () -> metrixAnalysis.runAnalysis(""));
     }
 
@@ -108,7 +110,8 @@ public class MetrixExceptionTest {
         NetworkSource networkSource = new DefaultNetworkSourceImpl(networkFile, computationManager);
         Reader metrixDslReader = Files.newBufferedReader(wrongDslFile, StandardCharsets.UTF_8);
         Reader mappingReader = Files.newBufferedReader(emptyDslFile, StandardCharsets.UTF_8);
-        MetrixAnalysis metrixAnalysis = new MetrixAnalysis(networkSource, mappingReader, metrixDslReader, null, null,
+        TimeSeriesDslLoader timeSeriesDslLoader = new TimeSeriesDslLoader(mappingReader);
+        MetrixAnalysis metrixAnalysis = new MetrixAnalysis(networkSource, timeSeriesDslLoader, metrixDslReader, null, null,
                 new ReadOnlyTimeSeriesStoreCache(), appLogger, null);
         assertThrows(MetrixScriptLoadingException.class, () -> metrixAnalysis.runAnalysis(""));
     }

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixInputTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixInputTest.java
@@ -387,7 +387,7 @@ class MetrixInputTest {
         try (Reader mappingReader = Files.newBufferedReader(mappingFile, StandardCharsets.UTF_8)) {
             ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
             MappingParameters mappingParameters = MappingParameters.load();
-            TimeSeriesMappingConfig mappingConfig = TimeSeriesDslLoader.load(mappingReader, n, mappingParameters, store, new DataTableStore(), null, null);
+            TimeSeriesMappingConfig mappingConfig = new TimeSeriesDslLoader(mappingReader).load(n, mappingParameters, store, new DataTableStore(), null, null);
             MetrixChunkParam metrixChunkParam = new MetrixChunkParam.MetrixChunkParamBuilder()
                     .simpleInit(1, false, false, __ -> Collections.emptyList(),
                             null, null, null, null).build();

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixTimeSeriesVariantsProviderTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixTimeSeriesVariantsProviderTest.java
@@ -104,7 +104,7 @@ class MetrixTimeSeriesVariantsProviderTest {
 
         TimeSeriesMappingConfig mappingConfig;
         try (Reader mappingReader = new InputStreamReader(MetrixConstantVariantTest.class.getResourceAsStream("/inputs/constantVariantTestMappingInput.groovy"), StandardCharsets.UTF_8)) {
-            mappingConfig = TimeSeriesDslLoader.load(mappingReader, network, mappingParameters, store, new DataTableStore(), null, null);
+            mappingConfig = new TimeSeriesDslLoader(mappingReader).load(network, mappingParameters, store, new DataTableStore(), null, null);
         }
 
         try (Reader metrixDslReader = Files.newBufferedReader(metrixFile, StandardCharsets.UTF_8)) {

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
@@ -21,7 +21,6 @@ import org.codehaus.groovy.control.customizers.ImportCustomizer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
@@ -41,6 +41,7 @@ class TimeSeriesDslLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(TimeSeriesDslLoader.class)
 
     private static final String MAPPING_SCRIPT_SECTION = "Mapping script"
+    protected static final String DEFAULT_MAPPING_SCRIPT_NAME = "mapping.groovy"
 
     protected final GroovyCodeSource dslSrc
 
@@ -56,8 +57,16 @@ class TimeSeriesDslLoader {
         this(new GroovyCodeSource(script, "script", GroovyShell.DEFAULT_CODE_BASE))
     }
 
+    TimeSeriesDslLoader(Reader reader) {
+        this(new GroovyCodeSource(reader, DEFAULT_MAPPING_SCRIPT_NAME, GroovyShell.DEFAULT_CODE_BASE))
+    }
+
     TimeSeriesDslLoader(Reader reader, String fileName) {
         this(new GroovyCodeSource(reader, fileName, GroovyShell.DEFAULT_CODE_BASE))
+    }
+
+    TimeSeriesDslLoader(Path path) {
+        this(Files.newBufferedReader(path), path.getFileName().toString())
     }
 
     private static logWarn(LogDslLoader logDslLoader, String message) {
@@ -271,22 +280,6 @@ class TimeSeriesDslLoader {
         keys.forEach({ key ->
             logWarn(logDslLoader, "provideTs - Time series can not be provided for id " + key.getId() + " because id is not mapped on " + key.getMappingVariable().getVariableName())
         })
-    }
-
-    static TimeSeriesMappingConfig load(Reader reader, Network network, MappingParameters parameters, ReadOnlyTimeSeriesStore store, DataTableStore dataTableStore, Writer out, ComputationRange computationRange) {
-        TimeSeriesDslLoader dslLoader = new TimeSeriesDslLoader(reader, "mapping.groovy")
-        dslLoader.load(network, parameters, store, dataTableStore, out, computationRange)
-    }
-
-    static TimeSeriesMappingConfig load(Path mappingFile, Network network, MappingParameters parameters, ReadOnlyTimeSeriesStore store, DataTableStore dataTableStore, ComputationRange computationRange) {
-        load(mappingFile, network, parameters, store, dataTableStore, null, computationRange)
-    }
-
-    static TimeSeriesMappingConfig load(Path mappingFile, Network network, MappingParameters parameters, ReadOnlyTimeSeriesStore store, DataTableStore dataTableStore, Writer out, ComputationRange computationRange) {
-        Files.newBufferedReader(mappingFile, StandardCharsets.UTF_8).withReader { Reader reader ->
-            TimeSeriesDslLoader dslLoader = new TimeSeriesDslLoader(reader, mappingFile.getFileName().toString())
-            dslLoader.load(network, parameters, store, dataTableStore, out, computationRange)
-        }
     }
 
     TimeSeriesMappingConfig load(Network network, MappingParameters parameters, ReadOnlyTimeSeriesStore store, DataTableStore dataTableStore, ComputationRange computationRange) {

--- a/metrix-mapping/src/test/resources/emptyScript.groovy
+++ b/metrix-mapping/src/test/resources/emptyScript.groovy
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */

--- a/metrix-tools/src/main/java/com/powsybl/metrix/tools/MetrixTool.java
+++ b/metrix-tools/src/main/java/com/powsybl/metrix/tools/MetrixTool.java
@@ -20,6 +20,7 @@ import com.powsybl.metrix.integration.compatibility.CsvResultListener;
 import com.powsybl.metrix.integration.metrix.MetrixAnalysis;
 import com.powsybl.metrix.integration.metrix.MetrixAnalysisResult;
 import com.powsybl.metrix.mapping.ComputationRange;
+import com.powsybl.metrix.mapping.TimeSeriesDslLoader;
 import com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore;
 import com.powsybl.metrix.mapping.timeseries.InMemoryTimeSeriesStore;
 import com.powsybl.tools.Command;
@@ -274,7 +275,8 @@ public class MetrixTool implements Tool {
         try (ZipOutputStream logArchive = createLogArchive(line, context, versions)) {
             MetrixRunParameters runParameters = new MetrixRunParameters(firstVariant, variantCount, versions, chunkSize, ignoreLimits, ignoreEmptyFilter, false);
             ComputationRange computationRange = new ComputationRange(runParameters.getVersions(), runParameters.getFirstVariant(), runParameters.getVariantCount());
-            MetrixAnalysis metrixAnalysis = new MetrixAnalysis(networkSource, mappingReader, metrixDslReader, remedialActionsReaderForAnalysis, contingenciesProvider,
+            TimeSeriesDslLoader timeSeriesDslLoader = new TimeSeriesDslLoader(mappingReader);
+            MetrixAnalysis metrixAnalysis = new MetrixAnalysis(networkSource, timeSeriesDslLoader, metrixDslReader, remedialActionsReaderForAnalysis, contingenciesProvider,
                     store, logger, computationRange);
             MetrixAnalysisResult analysisResult = metrixAnalysis.runAnalysis("extern tool");
             new Metrix(remedialActionsReaderForRun, store, resultStore, logArchive, context.getLongTimeExecutionComputationManager(), logger, analysisResult)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature

**What is the current behavior?**
<!-- You can also link to an open issue here -->
When using a `MetrixAnalysis`, the `load` method called inside `MetrixAnalysis` constructor is the static method from `TimeSeriesDslLoader` which creates a `TimeSeriesDslLoader`.

**What is the new behavior (if this is a feature change)?**
When using a `MetrixAnalysis`, the user now has to specify a `TimeSeriesDslLoader` in the parameters.
Therefore, you can now load mapping script with a super class of `TimeSeriesDslLoader`.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
