### PR TITLE
Network extraction impossible when network id contains brackets (or other problematic characters)

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixChunk.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixChunk.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixChunk.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixChunk.java
@@ -133,7 +133,10 @@ public class MetrixChunk {
 
                         if (networkPointFile != null) {
                             try (Stream<Path> paths = Files.list(workingDir)) {
-                                List<Path> files = paths.filter(path -> path.getFileName().toString().matches(network.getId() + "(.*)\\.xiidm")).collect(Collectors.toList());
+                                List<Path> files = paths.filter(path -> {
+                                    String fileName = path.getFileName().toString();
+                                    return fileName.startsWith(network.getId()) && fileName.endsWith("xiidm");
+                                }).collect(Collectors.toList());
                                 if (files.size() != 1) {
                                     LOGGER.error("More than one network point files '{}'", files.size());
                                     throw new MetrixException("More than one network point files " + files.size());

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixChunk.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixChunk.java
@@ -134,10 +134,7 @@ public class MetrixChunk {
 
                         if (networkPointFile != null) {
                             try (Stream<Path> paths = Files.list(workingDir)) {
-                                List<Path> files = paths.filter(path -> {
-                                    String fileName = path.getFileName().toString();
-                                    return fileName.startsWith(network.getId()) && fileName.endsWith("xiidm");
-                                }).collect(Collectors.toList());
+                                List<Path> files = paths.filter(path -> path.getFileName().toString().matches(Pattern.quote(network.getId()) + "(.*)\\.xiidm")).collect(Collectors.toList());
                                 if (files.size() != 1) {
                                     LOGGER.error("More than one network point files '{}'", files.size());
                                     throw new MetrixException("More than one network point files " + files.size());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
