### PR TITLE
Fix method that should not be static

### DIFF
--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
@@ -76,13 +76,13 @@ class TimeSeriesDslLoader {
         logDslLoader.logWarn(message)
     }
 
-    protected static List<String> getStaticStars() {
+    protected List<String> getStaticStars() {
         List<String> staticStars = new ArrayList<>()
         staticStars.add("com.powsybl.metrix.mapping.SimpleEquipmentGroupType")
         return staticStars
     }
 
-    private static CompilerConfiguration createCompilerConfig() {
+    private CompilerConfiguration createCompilerConfig() {
         def imports = new ImportCustomizer()
         imports.addStaticStars("com.powsybl.iidm.network.EnergySource")
         imports.addStaticStars("com.powsybl.iidm.network.Country")

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
@@ -44,6 +44,7 @@ class TimeSeriesDslLoader {
     protected static final String DEFAULT_MAPPING_SCRIPT_NAME = "mapping.groovy"
 
     protected final GroovyCodeSource dslSrc
+    protected String equipmentGroupTypes = "com.powsybl.metrix.mapping.SimpleEquipmentGroupType"
 
     TimeSeriesDslLoader(GroovyCodeSource dslSrc) {
         this.dslSrc = Objects.requireNonNull(dslSrc)
@@ -78,7 +79,7 @@ class TimeSeriesDslLoader {
 
     protected List<String> getStaticStars() {
         List<String> staticStars = new ArrayList<>()
-        staticStars.add("com.powsybl.metrix.mapping.SimpleEquipmentGroupType")
+        staticStars.add(equipmentGroupTypes)
         return staticStars
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
The methods `getStaticStars` and `createCompilerConfig` were declared static during Java 17 upgrade but it makes impossible to override those methods, which can be useful for users wanting to extend the class `TimeSeriesDslLoader`.

**What is the new behavior (if this is a feature change)?**
The two methods are not anymore static and a new variable (`equipmentGroupTypes`) is used to specify the class declaring the enum listing the equipment group types.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
