### PR TITLE
Fix FileSystemTimeseriesStore

### DIFF
--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStore.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStore.java
@@ -34,11 +34,22 @@ public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
     private final Map<String, Object> fileLocks = new ConcurrentHashMap<>();
 
     public FileSystemTimeseriesStore(Path path) throws IOException {
-        this.fileSystemStorePath = Objects.requireNonNull(path);
-        this.existingTimeSeriesMetadataCache = initExistingTimeSeriesCache();
-        if (!Files.isDirectory(path)) {
+        if (Files.exists(path) && !Files.isDirectory(path)) {
             throw new IllegalArgumentException(String.format("Path %s is not a directory", path));
         }
+        this.fileSystemStorePath = Objects.requireNonNull(path);
+        this.existingTimeSeriesMetadataCache = initExistingTimeSeriesCache();
+    }
+
+    private static void deleteRecursive(Path path) throws IOException {
+        if (Files.isDirectory(path)) {
+            try (Stream<Path> childlist = Files.list(path)) {
+                for (Path child : childlist.toList()) {
+                    deleteRecursive(child);
+                }
+            }
+        }
+        Files.delete(path);
     }
 
     @Override
@@ -86,31 +97,31 @@ public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
     }
 
     @Override
-    public Optional<DoubleTimeSeries> getDoubleTimeSeries(String s, int i) {
-        return getTimeSeries(DoubleTimeSeries.class, s, i);
+    public Optional<DoubleTimeSeries> getDoubleTimeSeries(String s, int version) {
+        return getTimeSeries(DoubleTimeSeries.class, s, version);
     }
 
     @Override
-    public List<DoubleTimeSeries> getDoubleTimeSeries(Set<String> set, int i) {
-        return set.stream().map(tsName -> getDoubleTimeSeries(tsName, i))
+    public List<DoubleTimeSeries> getDoubleTimeSeries(Set<String> set, int version) {
+        return set.stream().map(tsName -> getDoubleTimeSeries(tsName, version))
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(Collectors.toList());
     }
 
     @Override
-    public List<DoubleTimeSeries> getDoubleTimeSeries(int i) {
-        return getDoubleTimeSeries(existingTimeSeriesMetadataCache.keySet(), i);
+    public List<DoubleTimeSeries> getDoubleTimeSeries(int version) {
+        return getDoubleTimeSeries(existingTimeSeriesMetadataCache.keySet(), version);
     }
 
     @Override
-    public Optional<StringTimeSeries> getStringTimeSeries(String s, int i) {
-        return getTimeSeries(StringTimeSeries.class, s, i);
+    public Optional<StringTimeSeries> getStringTimeSeries(String s, int version) {
+        return getTimeSeries(StringTimeSeries.class, s, version);
     }
 
     @Override
-    public List<StringTimeSeries> getStringTimeSeries(Set<String> set, int i) {
-        return set.stream().map(tsName -> getStringTimeSeries(tsName, i))
+    public List<StringTimeSeries> getStringTimeSeries(Set<String> set, int version) {
+        return set.stream().map(tsName -> getStringTimeSeries(tsName, version))
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(Collectors.toList());
@@ -128,18 +139,21 @@ public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
             }
 
             List<T> timeSeries = TimeSeries.parseJson(tsPath).stream().map(ts -> {
-                if (timeSerieTypeClass.isAssignableFrom(DoubleTimeSeries.class) && TimeSeriesDataType.DOUBLE.equals(ts.getMetadata().getDataType())) {
-                    return timeSerieTypeClass.cast(ts);
+                Optional<T> optionalTimeSeries = Optional.empty();
+                if (timeSerieTypeClass.isAssignableFrom(DoubleTimeSeries.class) && TimeSeriesDataType.DOUBLE.equals(ts.getMetadata().getDataType())
+                    || timeSerieTypeClass.isAssignableFrom(StringTimeSeries.class) && TimeSeriesDataType.STRING.equals(ts.getMetadata().getDataType())) {
+                    optionalTimeSeries = Optional.of(timeSerieTypeClass.cast(ts));
                 }
-                if (timeSerieTypeClass.isAssignableFrom(StringTimeSeries.class) && TimeSeriesDataType.STRING.equals(ts.getMetadata().getDataType())) {
-                    return timeSerieTypeClass.cast(ts);
-                }
-                throw new PowsyblException(String.format("Wrong data type for timeseries %s", name));
-            }).toList();
-            if (timeSeries.size() != 1) {
-                throw new PowsyblException("Found more than one timeseries");
-            }
-            return Optional.of(timeSeries.get(0));
+                return optionalTimeSeries;
+            })
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
+            return switch (timeSeries.size()) {
+                case 0 -> Optional.empty();
+                case 1 -> Optional.of(timeSeries.get(0));
+                default -> throw new PowsyblException("Found more than one timeseries");
+            };
         }
     }
 
@@ -244,17 +258,6 @@ public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
         } catch (IOException e) {
             LOGGER.error("Failed to delete filesystem timeserie store", e);
         }
-    }
-
-    private static void deleteRecursive(Path path) throws IOException {
-        if (Files.isDirectory(path)) {
-            try (Stream<Path> childlist = Files.list(path)) {
-                for (Path child : childlist.toList()) {
-                    deleteRecursive(child);
-                }
-            }
-        }
-        Files.delete(path);
     }
 
 }

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStoreTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStoreTest.java
@@ -198,12 +198,12 @@ class FileSystemTimeseriesStoreTest {
         FileSystemTimeseriesStore tsStore = new FileSystemTimeseriesStore(resDir);
 
         // Add a file with multiple TimeSeries
-        Files.createDirectory(fileSystem.getPath("/tmp/ts1"));
+        Files.createDirectory(fileSystem.getPath("/tmp/ts2"));
         Files.copy(Objects.requireNonNull(getClass().getResourceAsStream("/timeseries.json")),
-            fileSystem.getPath("/tmp/ts1/1"));
+            fileSystem.getPath("/tmp/ts2/1"));
 
         // An exception is thrown since there are mutiple TimeSeries in the file
-        PowsyblException exception = assertThrows(PowsyblException.class, () -> tsStore.getDoubleTimeSeries("ts1", 1));
+        PowsyblException exception = assertThrows(PowsyblException.class, () -> tsStore.getDoubleTimeSeries("ts2", 1));
         assertEquals("Found more than one timeseries", exception.getMessage());
     }
 }

--- a/metrix-mapping/src/test/resources/timeseries.json
+++ b/metrix-mapping/src/test/resources/timeseries.json
@@ -1,0 +1,31 @@
+[{
+  "metadata" : {
+    "name" : "ts1",
+    "dataType" : "DOUBLE",
+    "tags" : [ ],
+    "regularIndex" : {
+      "startTime" : 978303600000,
+      "endTime" : 978310800000,
+      "spacing" : 3600000
+    }
+  },
+  "chunks" : [ {
+    "offset" : 0,
+    "values" : [ 1.0, 2.0, 3.0 ]
+  } ]
+}, {
+  "metadata" : {
+    "name" : "ts5",
+    "dataType" : "DOUBLE",
+    "tags" : [ ],
+    "regularIndex" : {
+      "startTime" : 978303600000,
+      "endTime" : 978310800000,
+      "spacing" : 3600000
+    }
+  },
+  "chunks" : [ {
+    "offset" : 0,
+    "values" : [ 1.0, 2.0, 3.0 ]
+  } ]
+}]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
The first issue is that a wrong exception is thrown if the path provided during FileSystemTimeseriesStore creation is not a directory.

During a call to `getTimeSeries()`, the returned Optional can not be empty:
- If a TimeSeries of the wrong subClass (`DoubleTimeSeries` or `StringTimeSeries`) is found, an exception is thrown
- If multiple TimeSeries of the right subClass are found, an exception is thrown
- If a single TimeSeries of the right subClass is found, it is returned in an Optional

**What is the new behavior (if this is a feature change)?**
The expected exception is now thrown immediately if the path provided during FileSystemTimeseriesStore creation exists but is not a directory.

During a call to `getTimeSeries()`, the returned Optional can now be empty:
- If multiple TimeSeries of the right subClass are found, an exception is thrown
- If a single TimeSeries of the right subClass is found, it is returned in an Optional
- If no TimeSeries of the right subClass is found (i.e. there are no TimeSeries, or none is of the right subClass), an `Optional.empty()` is returned

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
