### PR TITLE
Fix importTimeSeries method in FileSystemTimeseriesStore

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/compatibility/CsvResultListener.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/compatibility/CsvResultListener.java
@@ -43,7 +43,7 @@ public class CsvResultListener implements ResultListener {
 
     @Override
     public void onChunkResult(int version, int chunk, List<TimeSeries> timeSeriesList, Network networkPoint) {
-        resultStore.importTimeSeries(timeSeriesList, version, FileSystemTimeseriesStore.ExistingFiles.APPEND);
+        resultStore.importTimeSeries(timeSeriesList, version, FileSystemTimeseriesStore.ExistingFilePolicy.APPEND);
     }
 
     @Override

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/compatibility/CsvResultListener.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/compatibility/CsvResultListener.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.metrix.integration.compatibility;
 
+import com.google.common.base.Stopwatch;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.metrix.integration.io.ResultListener;
 import com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore;
@@ -26,8 +27,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 
-import com.google.common.base.Stopwatch;
-
 public class CsvResultListener implements ResultListener {
 
     private final Path csvResultFilePath;
@@ -44,7 +43,7 @@ public class CsvResultListener implements ResultListener {
 
     @Override
     public void onChunkResult(int version, int chunk, List<TimeSeries> timeSeriesList, Network networkPoint) {
-        resultStore.importTimeSeries(timeSeriesList, version, false, true);
+        resultStore.importTimeSeries(timeSeriesList, version, FileSystemTimeseriesStore.ExistingFiles.APPEND);
     }
 
     @Override

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStore.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStore.java
@@ -19,10 +19,14 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
@@ -39,6 +43,12 @@ public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
         }
         this.fileSystemStorePath = Objects.requireNonNull(path);
         this.existingTimeSeriesMetadataCache = initExistingTimeSeriesCache();
+    }
+
+    public enum ExistingFiles {
+        KEEP_EXISTING,
+        OVERWRITE,
+        APPEND
     }
 
     private static void deleteRecursive(Path path) throws IOException {
@@ -167,18 +177,48 @@ public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
         throw new NotImplementedException("Not impletemented");
     }
 
+    /**
+     * Import a list of TimeSeries in the current FileSystemTimeseriesStore
+     * @deprecated use {@link #importTimeSeries(List, int, ExistingFiles)} instead
+     */
+    @Deprecated(since = "2.3.0")
     public void importTimeSeries(List<TimeSeries> timeSeriesList, int version, boolean overwriteExisting, boolean append) {
+        ExistingFiles existingFiles;
+        if (append) {
+            existingFiles = ExistingFiles.APPEND;
+        } else if (overwriteExisting) {
+            existingFiles = ExistingFiles.OVERWRITE;
+        } else {
+            existingFiles = ExistingFiles.KEEP_EXISTING;
+        }
+        importTimeSeries(timeSeriesList, version, existingFiles);
+    }
+
+
+    /**
+     * Import a list of TimeSeries in the current FileSystemTimeseriesStore.<br>
+     * If a file already exists for such TimeSeries, the new TimeSeries will be appended to it
+     */
+    public void importTimeSeries(List<TimeSeries> timeSeriesList, int version) {
+        importTimeSeries(timeSeriesList, version, ExistingFiles.APPEND);
+    }
+
+    /**
+     * Import a list of TimeSeries in the current FileSystemTimeseriesStore.<br>
+     * If a file already exists for such TimeSeries, depending on {@code existingFiles}, the existing file will either
+     * be kept as it is, overwritten or the new TimeSeries will be appended to it
+     */
+    public void importTimeSeries(List<TimeSeries> timeSeriesList, int version, ExistingFiles existingFiles) {
         timeSeriesList.forEach(ts -> {
             String tsName = ts.getMetadata().getName();
-            existingTimeSeriesMetadataCache.put(tsName, ts.getMetadata());
             try {
                 Path tsFolder = Files.createDirectories(fileSystemStorePath.resolve(tsName));
                 Path versionFile = tsFolder.resolve(String.valueOf(version));
-                if (!append && !overwriteExisting && Files.exists(versionFile)) {
+                if (existingFiles == ExistingFiles.KEEP_EXISTING && Files.exists(versionFile)) {
                     throw new PowsyblException(String.format("Timeserie %s already exist", tsName));
                 }
                 synchronized (getFileLock(versionFile.toString())) {
-                    manageVersionFile(ts, versionFile, append);
+                    manageVersionFile(ts, versionFile, existingFiles);
                 }
             } catch (IOException e) {
                 throw new PowsyblException("Failed to write timeseries", e);
@@ -186,34 +226,165 @@ public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
         });
     }
 
-    private void manageVersionFile(TimeSeries ts, Path versionFile, boolean append) throws IOException {
+    private void manageVersionFile(TimeSeries ts, Path versionFile, ExistingFiles existingFiles) throws IOException {
         TimeSeries updatedTs = ts;
         if (Files.exists(versionFile)) {
-            List<TimeSeries> existingTsList = TimeSeries.parseJson(versionFile);
-            if (existingTsList.size() != 1) {
-                throw new PowsyblException("Existing ts file should contain one and only one ts");
-            }
-            TimeSeries existingTs = existingTsList.get(0);
-            if (append && InfiniteTimeSeriesIndex.INSTANCE.getType().equals(existingTs.getMetadata().getIndex().getType())) {
-                throw new PowsyblException("Cannot append to a calculated timeserie");
-            } else {
+            // A file already exists
+
+            if (existingFiles == ExistingFiles.APPEND) {
+                // Get the existing TimeSeries
+                List<TimeSeries> existingTsList = TimeSeries.parseJson(versionFile);
+                if (existingTsList.size() != 1) {
+                    throw new PowsyblException("Existing ts file should contain one and only one ts");
+                }
+                TimeSeries existingTs = existingTsList.get(0);
+
+                // You cannot append to an infinite TimeSeries
+                if (InfiniteTimeSeriesIndex.INSTANCE.getType().equals(existingTs.getMetadata().getIndex().getType())
+                    || InfiniteTimeSeriesIndex.INSTANCE.getType().equals(ts.getMetadata().getIndex().getType())) {
+                    throw new PowsyblException("Cannot append a TimeSeries with infinite index");
+                }
+
+                // Type of the new TimeSeries
                 TimeSeriesDataType dataType = ts.getMetadata().getDataType();
 
-                if (dataType.equals(TimeSeriesDataType.DOUBLE)) {
-                    List<DoubleDataChunk> chunks = ((StoredDoubleTimeSeries) existingTs).getChunks();
-                    chunks.addAll(((StoredDoubleTimeSeries) ts).getChunks());
-                    updatedTs = new StoredDoubleTimeSeries(existingTs.getMetadata(), chunks);
-                } else {
-                    List<StringDataChunk> chunks = ((StringTimeSeries) existingTs).getChunks();
-                    chunks.addAll(((StringTimeSeries) ts).getChunks());
-                    updatedTs = new StringTimeSeries(existingTs.getMetadata(), chunks);
+                // You cannot append to a TimeSeries of a different type
+                if (!dataType.equals(existingTs.getMetadata().getDataType())) {
+                    throw new PowsyblException("Cannot append to a TimeSeries with different data type");
                 }
+
+                // Append the data
+                updatedTs = appendTimeSeries(existingTs, ts, dataType);
             }
         } else {
+            // Initialize a new empty file
             Files.createFile(versionFile);
         }
         try (BufferedWriter bf = Files.newBufferedWriter(versionFile)) {
             bf.write(updatedTs.toJson());
+        }
+
+        // Update the Metadata cache
+        existingTimeSeriesMetadataCache.put(updatedTs.getMetadata().getName(), updatedTs.getMetadata());
+    }
+
+    private TimeSeries appendTimeSeries(TimeSeries existingTimeSeries, TimeSeries newTimeSeries, TimeSeriesDataType dataType) {
+        // Indexes to concatenate
+        TimeSeriesIndex existingIndex = existingTimeSeries.getMetadata().getIndex();
+        TimeSeriesIndex newIndex = newTimeSeries.getMetadata().getIndex();
+
+        // Sort the indexes
+        boolean existingComesFirst;
+        if (existingIndex.getInstantAt(existingIndex.getPointCount() - 1).isBefore(newIndex.getInstantAt(0))) {
+            existingComesFirst = true;
+        } else if (newIndex.getInstantAt(newIndex.getPointCount() - 1).isBefore(existingIndex.getInstantAt(0))) {
+            existingComesFirst = false;
+        } else {
+            throw new PowsyblException("Indexes to concatenate cannot overlap");
+        }
+
+        // Append the indexes
+        TimeSeriesIndex updatedIndex = appendTimeSeriesIndex(existingIndex, newIndex, existingComesFirst);
+
+        // Append the tags
+        Map<String, String> updatedTags = new HashMap<>(existingTimeSeries.getMetadata().getTags());
+        updatedTags.putAll(newTimeSeries.getMetadata().getTags());
+
+        // New metadata
+        TimeSeriesMetadata updatedMetadata = new TimeSeriesMetadata(existingTimeSeries.getMetadata().getName(), dataType, updatedTags, updatedIndex);
+
+        // Append the chunks
+        if (dataType.equals(TimeSeriesDataType.DOUBLE)) {
+            // Chunks
+            List<DoubleDataChunk> chunks = appendChunks(
+                ((StoredDoubleTimeSeries) existingTimeSeries).getChunks(),
+                ((StoredDoubleTimeSeries) newTimeSeries).getChunks(),
+                existingIndex, newIndex,
+                existingComesFirst);
+            return new StoredDoubleTimeSeries(updatedMetadata, chunks);
+        } else {
+            // Chunks
+            List<StringDataChunk> chunks = appendChunks(
+                ((StringTimeSeries) existingTimeSeries).getChunks(),
+                ((StringTimeSeries) newTimeSeries).getChunks(),
+                existingIndex, newIndex,
+                existingComesFirst);
+            return new StringTimeSeries(updatedMetadata, chunks);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends DataChunk> List<T> appendChunks(List<T> existingChunks, List<T> newChunks,
+                                                       TimeSeriesIndex existingIndex, TimeSeriesIndex newIndex,
+                                                       boolean existingComesFirst) {
+        // Sort the chunks
+        List<T> firstChunks;
+        List<T> lastChunks;
+        if (existingComesFirst) {
+            firstChunks = existingChunks;
+            lastChunks = newChunks;
+        } else {
+            firstChunks = newChunks;
+            lastChunks = existingChunks;
+        }
+
+        // Add the first chunks
+        List<T> chunks = new ArrayList<>(firstChunks);
+        final AtomicInteger offset = new AtomicInteger(existingComesFirst ? existingIndex.getPointCount() : newIndex.getPointCount());
+
+        // Add the other chunks
+        lastChunks.forEach(chunk -> {
+            T chunkWithOffset;
+            if (chunk instanceof DoubleDataChunk doubleChunk) {
+                chunkWithOffset = (T) new UncompressedDoubleDataChunk(
+                    offset.get(),
+                    doubleChunk
+                        .stream(newIndex)
+                        .map(DoublePoint::getValue)
+                        .mapToDouble(Double::doubleValue)
+                        .toArray()).tryToCompress();
+            } else if (chunk instanceof StringDataChunk stringChunk) {
+                chunkWithOffset = (T) new UncompressedStringDataChunk(
+                    offset.get(),
+                    stringChunk
+                        .stream(newIndex)
+                        .map(StringPoint::getValue)
+                        .toArray(String[]::new)).tryToCompress();
+            } else {
+                // This case should not happen
+                throw new PowsyblException("Unsupported chunk type: " + chunk.getClass().getName());
+            }
+            offset.addAndGet(chunkWithOffset.getLength());
+            chunks.add(chunkWithOffset);
+        });
+        return chunks;
+    }
+
+    private TimeSeriesIndex appendTimeSeriesIndex(TimeSeriesIndex existingIndex, TimeSeriesIndex newIndex, boolean existingComesFirst) {
+        if (existingIndex instanceof RegularTimeSeriesIndex regularExistingTimeSeriesIndex && newIndex instanceof RegularTimeSeriesIndex regularNewTimeSeriesIndex
+            && regularExistingTimeSeriesIndex.getSpacing() == regularNewTimeSeriesIndex.getSpacing()
+            && (existingComesFirst && Duration.between(
+                regularExistingTimeSeriesIndex.getInstantAt(regularExistingTimeSeriesIndex.getPointCount() - 1),
+                regularNewTimeSeriesIndex.getInstantAt(0))
+            .toMillis() == regularExistingTimeSeriesIndex.getSpacing()
+            || !existingComesFirst && Duration.between(
+                regularNewTimeSeriesIndex.getInstantAt(regularNewTimeSeriesIndex.getPointCount() - 1),
+                regularExistingTimeSeriesIndex.getInstantAt(0))
+            .toMillis() == regularExistingTimeSeriesIndex.getSpacing())) {
+            // If both indexes are regular, both spacing are equals and the space between the first and the second index is equal to the spacing, the updated index is also regular
+            return existingComesFirst ?
+                new RegularTimeSeriesIndex(regularExistingTimeSeriesIndex.getStartTime(), regularNewTimeSeriesIndex.getEndTime(), regularExistingTimeSeriesIndex.getSpacing()) :
+                new RegularTimeSeriesIndex(regularNewTimeSeriesIndex.getStartTime(), regularExistingTimeSeriesIndex.getEndTime(), regularExistingTimeSeriesIndex.getSpacing());
+        } else {
+            // Else the index is irregular
+            return new IrregularTimeSeriesIndex(existingComesFirst ?
+                LongStream.concat(
+                    existingIndex.stream().map(Instant::toEpochMilli).mapToLong(Long::longValue),
+                    newIndex.stream().map(Instant::toEpochMilli).mapToLong(Long::longValue)).toArray() :
+                LongStream.concat(
+                    newIndex.stream().map(Instant::toEpochMilli).mapToLong(Long::longValue),
+                    existingIndex.stream().map(Instant::toEpochMilli).mapToLong(Long::longValue)).toArray()
+            );
         }
     }
 

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStore.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStore.java
@@ -194,7 +194,6 @@ public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
         importTimeSeries(timeSeriesList, version, existingFiles);
     }
 
-
     /**
      * Import a list of TimeSeries in the current FileSystemTimeseriesStore.<br>
      * If a file already exists for such TimeSeries, the new TimeSeries will be appended to it
@@ -388,9 +387,24 @@ public class FileSystemTimeseriesStore implements ReadOnlyTimeSeriesStore {
         }
     }
 
+    /**
+     * Import a list of TimeSeries in the current FileSystemTimeseriesStore
+     * @deprecated use {@link #importTimeSeries(BufferedReader, ExistingFiles)}  instead
+     */
+    @Deprecated(since = "2.3.0")
     public void importTimeSeries(BufferedReader reader, boolean overwriteExisting, boolean append) {
         Map<Integer, List<TimeSeries>> integerListMap = TimeSeries.parseCsv(reader, new TimeSeriesCsvConfig(), ReportNode.NO_OP);
         integerListMap.forEach((key, value) -> importTimeSeries(value, key, overwriteExisting, append));
+    }
+
+    /**
+     * Import a list of TimeSeries in the current FileSystemTimeseriesStore.<br>
+     * If a file already exists for such TimeSeries, depending on {@code existingFiles}, the existing file will either
+     * be kept as it is, overwritten or the new TimeSeries will be appended to it
+     */
+    public void importTimeSeries(BufferedReader reader, ExistingFiles existingFiles) {
+        Map<Integer, List<TimeSeries>> integerListMap = TimeSeries.parseCsv(reader, new TimeSeriesCsvConfig(), ReportNode.NO_OP);
+        integerListMap.forEach((key, value) -> importTimeSeries(value, key, existingFiles));
     }
 
     private Map<String, TimeSeriesMetadata> initExistingTimeSeriesCache() throws IOException {

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigTableLoaderTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigTableLoaderTest.java
@@ -3,7 +3,9 @@ package com.powsybl.metrix.mapping;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore;
-import com.powsybl.timeseries.*;
+import com.powsybl.timeseries.RegularTimeSeriesIndex;
+import com.powsybl.timeseries.StoredDoubleTimeSeries;
+import com.powsybl.timeseries.TimeSeries;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.powsybl.metrix.mapping.TimeSeriesMappingConfigTableLoader.checkValues;
+import static com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore.ExistingFiles.APPEND;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -51,9 +54,9 @@ class TimeSeriesMappingConfigTableLoaderTest {
         // TimeSeriesStore
         Path resDir = Files.createDirectory(fileSystem.getPath("/tmp"));
         FileSystemTimeseriesStore tsStore = new FileSystemTimeseriesStore(resDir);
-        tsStore.importTimeSeries(List.of(ts1, ts2), 1, false, true);
-        tsStore.importTimeSeries(List.of(ts1), 2, false, true);
-        tsStore.importTimeSeries(List.of(ts3), -1, false, true);
+        tsStore.importTimeSeries(List.of(ts1, ts2), 1, APPEND);
+        tsStore.importTimeSeries(List.of(ts1), 2, APPEND);
+        tsStore.importTimeSeries(List.of(ts3), -1, APPEND);
 
         // Assertion when it works
         try {

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigTableLoaderTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigTableLoaderTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.powsybl.metrix.mapping.TimeSeriesMappingConfigTableLoader.checkValues;
-import static com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore.ExistingFiles.APPEND;
+import static com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore.ExistingFilePolicy.APPEND;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStoreTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStoreTest.java
@@ -50,7 +50,8 @@ class FileSystemTimeseriesStoreTest {
     }
 
     @Test
-    void testTsStore() throws IOException {
+    @Deprecated(since = "2.3.0")
+    void testTsStoreDeprecatedMethod() throws IOException {
         FileSystemTimeseriesStore tsStore = new FileSystemTimeseriesStore(resDir);
         Set<String> emptyTimeSeriesNames = tsStore.getTimeSeriesNames(null);
         assertThat(emptyTimeSeriesNames).isEmpty();
@@ -59,6 +60,28 @@ class FileSystemTimeseriesStoreTest {
              BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(resourceAsStream))
         ) {
             tsStore.importTimeSeries(bufferedReader, true, false);
+        }
+
+        assertThat(tsStore.getTimeSeriesNames(null)).isNotEmpty();
+        assertThat(tsStore.getTimeSeriesNames(null)).containsExactlyInAnyOrder("BALANCE", "tsX");
+
+        assertTrue(tsStore.timeSeriesExists("BALANCE"));
+        assertFalse(tsStore.timeSeriesExists("tsY"));
+
+        assertEquals(Set.of(1), tsStore.getTimeSeriesDataVersions());
+        assertEquals(Set.of(1), tsStore.getTimeSeriesDataVersions("BALANCE"));
+    }
+
+    @Test
+    void testTsStore() throws IOException {
+        FileSystemTimeseriesStore tsStore = new FileSystemTimeseriesStore(resDir);
+        Set<String> emptyTimeSeriesNames = tsStore.getTimeSeriesNames(null);
+        assertThat(emptyTimeSeriesNames).isEmpty();
+
+        try (InputStream resourceAsStream = Objects.requireNonNull(FileSystemTimeseriesStoreTest.class.getResourceAsStream("/testStore.csv"));
+             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(resourceAsStream))
+        ) {
+            tsStore.importTimeSeries(bufferedReader, OVERWRITE);
         }
 
         assertThat(tsStore.getTimeSeriesNames(null)).isNotEmpty();
@@ -498,10 +521,9 @@ class FileSystemTimeseriesStoreTest {
         assertArrayEquals(new double[] {1d, 2d, 3d, 4d, 5d, 6d}, storedTs1.toArray());
         assertEquals(2, storedTs1.getChunks().size());
         assertInstanceOf(IrregularTimeSeriesIndex.class, storedTs1.getMetadata().getIndex());
-        IrregularTimeSeriesIndex storedIndex1= (IrregularTimeSeriesIndex) storedTs1.getMetadata().getIndex();
+        IrregularTimeSeriesIndex storedIndex1 = (IrregularTimeSeriesIndex) storedTs1.getMetadata().getIndex();
         assertEquals(978303600000L, storedIndex1.getTimeAt(0));
         assertEquals(978343200000L, storedIndex1.getTimeAt(storedIndex1.getPointCount() - 1));
-
 
         assertTrue(tsStore.getDoubleTimeSeries("ts2", 1).isPresent());
         StoredDoubleTimeSeries storedTs2 = (StoredDoubleTimeSeries) tsStore.getDoubleTimeSeries("ts2", 1).get();
@@ -541,7 +563,7 @@ class FileSystemTimeseriesStoreTest {
         assertArrayEquals(new double[] {1d, 2d, 3d, 4d, 5d, 6d}, storedTs1.toArray());
         assertEquals(2, storedTs1.getChunks().size());
         assertInstanceOf(IrregularTimeSeriesIndex.class, storedTs1.getMetadata().getIndex());
-        IrregularTimeSeriesIndex storedIndex1= (IrregularTimeSeriesIndex) storedTs1.getMetadata().getIndex();
+        IrregularTimeSeriesIndex storedIndex1 = (IrregularTimeSeriesIndex) storedTs1.getMetadata().getIndex();
         assertEquals(978303600000L, storedIndex1.getTimeAt(0));
         assertEquals(978332400000L, storedIndex1.getTimeAt(storedIndex1.getPointCount() - 1));
     }

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStoreTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeseriesStoreTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore.ExistingFiles.*;
+import static com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore.ExistingFilePolicy.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -257,11 +257,11 @@ class FileSystemTimeseriesStoreTest {
         FileSystemTimeseriesStore tsStore = new FileSystemTimeseriesStore(resDir);
 
         // Works the first time
-        tsStore.importTimeSeries(timeSeriesList, 1, KEEP_EXISTING);
+        tsStore.importTimeSeries(timeSeriesList, 1, THROW_EXCEPTION);
 
         // Fails since it already exists
         PowsyblException exception = assertThrows(PowsyblException.class,
-            () -> tsStore.importTimeSeries(timeSeriesList, 1, KEEP_EXISTING));
+            () -> tsStore.importTimeSeries(timeSeriesList, 1, THROW_EXCEPTION));
         assertEquals("Timeserie ts1 already exist", exception.getMessage());
     }
 

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesStoreUtilsTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesStoreUtilsTest.java
@@ -32,7 +32,9 @@ import java.util.*;
 import java.util.function.IntFunction;
 
 import static com.powsybl.metrix.mapping.AbstractCompareTxt.compareStreamTxt;
-import static com.powsybl.metrix.mapping.timeseries.TimeSeriesStoreUtil.*;
+import static com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore.ExistingFiles.APPEND;
+import static com.powsybl.metrix.mapping.timeseries.TimeSeriesStoreUtil.isNotVersioned;
+import static com.powsybl.metrix.mapping.timeseries.TimeSeriesStoreUtil.toTable;
 import static com.powsybl.timeseries.TimeSeries.DEFAULT_VERSION_NUMBER_FOR_UNVERSIONED_TIMESERIES;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -98,8 +100,8 @@ class TimeSeriesStoreUtilsTest {
         // TimeSeriesStore
         Path resDir = Files.createDirectory(fileSystem.getPath("/tmp"));
         FileSystemTimeseriesStore tsStore = new FileSystemTimeseriesStore(resDir);
-        tsStore.importTimeSeries(List.of(ts1, ts3), 1, false, true);
-        tsStore.importTimeSeries(List.of(ts1, ts3), 2, false, true);
+        tsStore.importTimeSeries(List.of(ts1, ts3), 1, APPEND);
+        tsStore.importTimeSeries(List.of(ts1, ts3), 2, APPEND);
 
         // Versions
         NavigableSet<Integer> versions = new TreeSet<>(List.of(1, 2));
@@ -156,8 +158,8 @@ class TimeSeriesStoreUtilsTest {
         // TimeSeriesStore
         Path resDir = Files.createDirectory(fileSystem.getPath("/tmp"));
         FileSystemTimeseriesStore tsStore = new FileSystemTimeseriesStore(resDir);
-        tsStore.importTimeSeries(List.of(ts1, ts2, ts4), 1, false, true);
-        tsStore.importTimeSeries(List.of(ts1, ts2, ts4), 2, false, true);
+        tsStore.importTimeSeries(List.of(ts1, ts2, ts4), 1, APPEND);
+        tsStore.importTimeSeries(List.of(ts1, ts2, ts4), 2, APPEND);
 
         // Versions
         NavigableSet<Integer> versions = new TreeSet<>(List.of(1, 2));

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesStoreUtilsTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesStoreUtilsTest.java
@@ -32,7 +32,7 @@ import java.util.*;
 import java.util.function.IntFunction;
 
 import static com.powsybl.metrix.mapping.AbstractCompareTxt.compareStreamTxt;
-import static com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore.ExistingFiles.APPEND;
+import static com.powsybl.metrix.mapping.timeseries.FileSystemTimeseriesStore.ExistingFilePolicy.APPEND;
 import static com.powsybl.metrix.mapping.timeseries.TimeSeriesStoreUtil.isNotVersioned;
 import static com.powsybl.metrix.mapping.timeseries.TimeSeriesStoreUtil.toTable;
 import static com.powsybl.timeseries.TimeSeries.DEFAULT_VERSION_NUMBER_FOR_UNVERSIONED_TIMESERIES;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
The current `importTimeSeries` method takes two booleans as parameters: `overwriteExisting` and `append`. However, an existing file cannot be overwritten (overwriteExisting` is only used with `append` to throw an exception when both booleans are false and a file already exists).

There is also no check that `overwriteExisting` and `append` cannot be true at the same time.

When a file already exists and `append` is true, the TimeSeriesIndex was not updated so only part of the chunks could be evaluated.
The chunks added were also not given an offset.

**What is the new behavior (if this is a feature change)?**
The method `importTimeSeries` now takes an enum `ExistingFilePolicy` that can take the following values: `THROW_EXCEPTION`, `OVERWRITE`, and `APPEND` instead of the booleans.
Checks were added for consistency and TimeSeries appending is now properly done.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
The method `importTimeSeries(List, int, boolean, boolean)` is now deprecated. You should instead use `importTimeSeries(List, int, ExistingFiles)`.