### PR TITLE
Fix action version in CentOS 7 CI

### DIFF
--- a/.github/workflows/ci_centos7.yml
+++ b/.github/workflows/ci_centos7.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Download Boost-release
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # v1.1.1
         with:
           repo: 'ARnDOSrte/Boost'
           file: 'boost_1_73_0.zip'

--- a/.github/workflows/qa_pr_cpp_centos7.yml
+++ b/.github/workflows/qa_pr_cpp_centos7.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Download Boost-release
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # v1.1.1
         with:
           repo: 'ARnDOSrte/Boost'
           file: 'boost_1_73_0.zip'
@@ -164,7 +164,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Download Boost-release
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # v1.1.1
         with:
           repo: 'ARnDOSrte/Boost'
           file: 'boost_1_73_0.zip'
@@ -229,7 +229,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Download Boost-release
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # v1.1.1
         with:
           repo: 'ARnDOSrte/Boost'
           file: 'boost_1_73_0.zip'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
CI modification


**What is the current behavior?**
The version of the action `dsaltares/fetch-gh-release-asset` used was the `master`. However, they just upgraded to Node20 in version `1.1.2`, which needs a version of a compiler not available on CentOS7.


**What is the new behavior (if this is a feature change)?**
The version used is now `1.1.1`.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
