### PR TITLE
[IMG-2331] Statistics computation on all steps/versions by default

### DIFF
--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
@@ -248,19 +248,19 @@ class TimeSeriesDslLoader {
         }
 
         // statistics
-        binding.sum = { NodeCalc tsNode, Boolean all_versions = false ->
+        binding.sum = { NodeCalc tsNode, Boolean all_versions = true ->
             stats.getTimeSeriesSum(tsNode, all_versions ? fullComputationRange : checkedComputationRange)
         }
-        binding.min = { NodeCalc tsNode, Boolean all_versions = false ->
+        binding.min = { NodeCalc tsNode, Boolean all_versions = true ->
             stats.getTimeSeriesMin(tsNode, all_versions ? fullComputationRange : checkedComputationRange)
         }
-        binding.max = { NodeCalc tsNode, Boolean all_versions = false ->
+        binding.max = { NodeCalc tsNode, Boolean all_versions = true ->
             stats.getTimeSeriesMax(tsNode, all_versions ? fullComputationRange : checkedComputationRange)
         }
-        binding.avg = { NodeCalc tsNode, Boolean all_versions = false ->
+        binding.avg = { NodeCalc tsNode, Boolean all_versions = true ->
             stats.getTimeSeriesAvg(tsNode, all_versions ? fullComputationRange : checkedComputationRange)
         }
-        binding.median = { NodeCalc tsNode, Boolean all_versions = false ->
+        binding.median = { NodeCalc tsNode, Boolean all_versions = true ->
             stats.getTimeSeriesMedian(tsNode, all_versions ? fullComputationRange : checkedComputationRange)
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Statistics functions (sum, min, max, avg, median) used in groovy scripts on time series are computed by default on range/versions defined by the current computation.
The consequence is that results of computation using such functions are by default dependent on launched range/versions.




**What is the new behavior (if this is a feature change)?**
Statistics functions are computed by default on all existing steps/versions of time series.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Add all_versions = false in groovy script when statistics must be computed on launched range/versions only. 
min(ts['ts name']**, all_versions = false**)
max(ts['ts name']**, all_versions = false**)
sum(ts['ts name']**, all_versions = false**)
avg(ts['ts name']**, all_versions = false**)
median(ts['ts name']**, all_versions = false**)

