### PR TITLE
[IMG-2340] phaseTapPosition mapping outside the steps interval

### DIFF
--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/log/RangeLogPhaseTapPosition.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/log/RangeLogPhaseTapPosition.java
@@ -1,0 +1,58 @@
+package com.powsybl.metrix.mapping.log;
+
+import com.powsybl.metrix.mapping.EquipmentVariable;
+
+public class RangeLogPhaseTapPosition implements LogDescriptionBuilder {
+    private String id;
+    private String value;
+    private String minValue;
+    private String maxValue;
+    private String newValue;
+    private String toVariable;
+
+    private static final String PHASE_TAP_POSTION_VARIABLE_NAME = EquipmentVariable.phaseTapPosition.getVariableName();
+    private static final String MAPPING_RANGE_PROBLEM = "mapping range problem" + LABEL_SEPARATOR;
+
+    public String getLabel() {
+        return String.format("%s%s changed to %s", MAPPING_RANGE_PROBLEM, PHASE_TAP_POSTION_VARIABLE_NAME,
+                toVariable);
+    }
+
+    public RangeLogPhaseTapPosition id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public RangeLogPhaseTapPosition newValue(double newValue) {
+        this.newValue = formatDouble(newValue);
+        return this;
+    }
+
+    public RangeLogPhaseTapPosition value(double value) {
+        this.value = formatDouble(value);
+        return this;
+    }
+
+    public RangeLogPhaseTapPosition minValue(double minValue) {
+        this.minValue = formatDouble(minValue);
+        return this;
+    }
+
+    public RangeLogPhaseTapPosition maxValue(double maxValue) {
+        this.maxValue = formatDouble(maxValue);
+        return this;
+    }
+
+    public RangeLogPhaseTapPosition toVariable(String toVariable) {
+        this.toVariable = toVariable;
+        return this;
+    }
+
+    public LogContent build() {
+        LogContent log = new LogContent();
+        log.label = getLabel();
+        log.message = String.format("%s %s of %s not included in %s to %s, %s changed to %s", PHASE_TAP_POSTION_VARIABLE_NAME,
+                value, id, minValue, maxValue, PHASE_TAP_POSTION_VARIABLE_NAME, newValue);
+        return log;
+    }
+}

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperCheckerTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperCheckerTest.java
@@ -1409,7 +1409,7 @@ class TimeSeriesMapperCheckerTest {
 
         // Add twoWindingsTransformer without phaseTapChanger
         TwoWindingsTransformer twoWindingsTransformer = network.getTwoWindingsTransformer("NE_NO_1");
-        Substation substation = twoWindingsTransformer.getSubstation().get();
+        Substation substation = network.getSubstation("NO");
         substation.newTwoWindingsTransformer()
                 .setId("twt")
                 .setVoltageLevel1(twoWindingsTransformer.getTerminal1().getVoltageLevel().getId())

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperCheckerTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperCheckerTest.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.metrix.mapping;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.powsybl.commons.test.TestUtil;
 import com.powsybl.commons.datasource.MemDataSource;
@@ -29,8 +28,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.TreeSet;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class TimeSeriesMapperCheckerTest {
 
@@ -239,9 +237,9 @@ class TimeSeriesMapperCheckerTest {
 
     private Network createNetwork() {
         Network network = NetworkSerDe.read(Objects.requireNonNull(getClass().getResourceAsStream("/simpleNetwork.xiidm")));
-        List<String> generators = ImmutableList.of("SO_G1", "SO_G2", "SE_G", "N_G");
+        List<String> generators = List.of("SO_G1", "SO_G2", "SE_G", "N_G");
         generators.forEach(id -> network.getGenerator(id).setTargetP(0));
-        List<String> loads = ImmutableList.of("SO_L", "SE_L1", "SE_L2");
+        List<String> loads = List.of("SO_L", "SE_L1", "SE_L2");
         loads.forEach(id -> network.getLoad(id).setP0(0));
         return network;
     }
@@ -382,7 +380,7 @@ class TimeSeriesMapperCheckerTest {
         BalanceSummary balanceSummary = new BalanceSummary();
         MemDataSource dataSource = new MemDataSource();
         NetworkPointWriter networkPointWriter = new NetworkPointWriter(network, dataSource);
-        mapper.mapToNetwork(store, ImmutableList.of(balanceSummary, networkPointWriter));
+        mapper.mapToNetwork(store, List.of(balanceSummary, networkPointWriter));
 
         compareNetworkPointGenerator(generator, dataSource, expectedMinP, expectedP, expectedMaxP);
         compareBalance(balanceSummary, expectedBalanceValue);
@@ -434,7 +432,7 @@ class TimeSeriesMapperCheckerTest {
 
         MemDataSource dataSource = new MemDataSource();
         NetworkPointWriter networkPointWriter = new NetworkPointWriter(network, dataSource);
-        mapper.mapToNetwork(store, ImmutableList.of(networkPointWriter));
+        mapper.mapToNetwork(store, List.of(networkPointWriter));
 
         compareNetworkPointHvdcLine(hvdcLine, dataSource, expectedSetPoint, expectedMaxP, expectedCS2toCS1, expectedCS1toCS2);
         compareLogger(logger, expectedType, expectedLabel, expectedSynthesisLabel, expectedVariant, expectedMessage, expectedSynthesisMessage);
@@ -452,7 +450,7 @@ class TimeSeriesMapperCheckerTest {
 
         MemDataSource dataSource = new MemDataSource();
         NetworkPointWriter networkPointWriter = new NetworkPointWriter(network, dataSource);
-        mapper.mapToNetwork(store, ImmutableList.of(networkPointWriter));
+        mapper.mapToNetwork(store, List.of(networkPointWriter));
 
         compareNetworkPointPhaseTapChanger(twoWindingsTransformer, dataSource, expectedPhaseTapPosition);
         compareLogger(logger, expectedType, expectedLabel, expectedSynthesisLabel, expectedVariant, expectedMessage, expectedSynthesisMessage);
@@ -1401,6 +1399,13 @@ class TimeSeriesMapperCheckerTest {
     /*
      * PHASE TAP CHANGER TEST
      */
+
+    @Test
+    void isTwoWindingsTransformerWithOutOfBoundsPhaseTapPosition() {
+        Network network = createNetwork();
+        assertFalse(TimeSeriesMapperChecker.isTwoWindingsTransformerWithOutOfBoundsPhaseTapPosition(network.getIdentifiable("HVDC1"), EquipmentVariable.p0, 100));
+        assertTrue(TimeSeriesMapperChecker.isTwoWindingsTransformerWithOutOfBoundsPhaseTapPosition(network.getIdentifiable("NE_NO_1"), EquipmentVariable.phaseTapPosition, 100));
+    }
 
     @Test
     void mappingRangeProblemPhaseTapChangerTest() {

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperCheckerTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperCheckerTest.java
@@ -10,9 +10,7 @@ package com.powsybl.metrix.mapping;
 import com.google.common.collect.Range;
 import com.powsybl.commons.test.TestUtil;
 import com.powsybl.commons.datasource.MemDataSource;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.HvdcLine;
-import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControl;
 import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRange;
 import com.powsybl.iidm.serde.NetworkSerDe;
@@ -1405,6 +1403,20 @@ class TimeSeriesMapperCheckerTest {
         Network network = createNetwork();
         assertFalse(TimeSeriesMapperChecker.isTwoWindingsTransformerWithOutOfBoundsPhaseTapPosition(network.getIdentifiable("HVDC1"), EquipmentVariable.p0, 100));
         assertTrue(TimeSeriesMapperChecker.isTwoWindingsTransformerWithOutOfBoundsPhaseTapPosition(network.getIdentifiable("NE_NO_1"), EquipmentVariable.phaseTapPosition, 100));
+
+        // Add twoWindingsTransformer without phaseTapChanger
+        TwoWindingsTransformer twoWindingsTransformer = network.getTwoWindingsTransformer("NE_NO_1");
+        Substation substation = twoWindingsTransformer.getSubstation().get();
+        substation.newTwoWindingsTransformer()
+                .setId("twt")
+                .setVoltageLevel1(twoWindingsTransformer.getTerminal1().getVoltageLevel().getId())
+                .setVoltageLevel2(twoWindingsTransformer.getTerminal2().getVoltageLevel().getId())
+                .setNode1(13)
+                .setNode2(14)
+                .setR(twoWindingsTransformer.getR())
+                .setX(twoWindingsTransformer.getX())
+                .add();
+        assertFalse(TimeSeriesMapperChecker.isTwoWindingsTransformerWithOutOfBoundsPhaseTapPosition(network.getIdentifiable("twt"), EquipmentVariable.phaseTapPosition, 10));
     }
 
     @Test

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperCheckerTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperCheckerTest.java
@@ -9,6 +9,7 @@ package com.powsybl.metrix.mapping;
 
 import com.google.common.collect.Range;
 import com.powsybl.commons.datasource.MemDataSource;
+import com.powsybl.commons.test.TestUtil;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControl;
 import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRange;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
this feature is about groovy script mapToPhaseTapChangers usage on phaseTapPosition variable
if mapped phaseTapPosition value is outside steps interval, no mapping is done


**What is the new behavior (if this is a feature change)?**
if mapped phaseTapPosition value is outside steps interval, mapping is done with a corrected value

if mapped phaseTapPosition value is < lowTapPosition, mapping is done with lowTapPosition value
if mapped phaseTapPosition value is > highTapPosition, mapping is done with highTapPosition value


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
