### PR TITLE
[IMG-2339] allow the use of 'name' variable in groovy script

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixVariable.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixVariable.java
@@ -37,11 +37,7 @@ public enum MetrixVariable implements MappingVariable {
     thresholdITAMNkEndOr("thresholdITAMNkEndOr"),
     curativeCostDown("curativeCostDown");
 
-    private static final String NAME = "metrix";
-
-    static String getName() {
-        return NAME;
-    }
+    protected static final String NAME = "metrix";
 
     @Override
     public String getFieldName() {

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixVariableProvider.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixVariableProvider.java
@@ -29,6 +29,6 @@ public class MetrixVariableProvider implements MappingVariableProvider<MetrixVar
 
     @Override
     public String getFieldName() {
-        return MetrixVariable.getName();
+        return MetrixVariable.NAME;
     }
 }

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/EquipmentVariable.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/EquipmentVariable.java
@@ -49,15 +49,11 @@ public enum EquipmentVariable implements MappingVariable {
     disconnected("disconnected"),
     targetDeadband("targetDeadband");
 
-    private static final String NAME = "equipment";
-
-    static String getName() {
-        return NAME;
-    }
+    protected static final String NAME = "equipment";
 
     @Override
     public String getFieldName() {
-        return getName();
+        return NAME;
     }
 
     static void writeJson(EquipmentVariable variable, JsonGenerator generator) throws IOException {

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/EquipmentVariableProvider.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/EquipmentVariableProvider.java
@@ -27,6 +27,6 @@ public class EquipmentVariableProvider implements MappingVariableProvider<Equipm
 
     @Override
     public String getFieldName() {
-        return EquipmentVariable.getName();
+        return EquipmentVariable.NAME;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Impossible to use a variable called 'name' into mapping script because it is hidden by the static function getName() from EquipmentVariable class which returns the string "equipment"
A mapping script containing at first line println('name = ' + name) has "equipment" as result


**What is the new behavior (if this is a feature change)?**
Allow the use of 'name' variable in groovy script


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
