### PR TITLE
Update CentOS CI due to CentOS EOL and Node 16 deprecation

### DIFF
--- a/.github/workflows/ci_centos7.yml
+++ b/.github/workflows/ci_centos7.yml
@@ -22,6 +22,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   linux:
     name: Tests C++ CentOS

--- a/.github/workflows/ci_centos7.yml
+++ b/.github/workflows/ci_centos7.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
           yum update -y
           yum install -y epel-release
           yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils

--- a/.github/workflows/ci_centos7.yml
+++ b/.github/workflows/ci_centos7.yml
@@ -45,6 +45,11 @@ jobs:
         run: |
           yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils
 
+      - name: Update mirrors again because why not
+        run: |
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
       - name: Install Dependencies 3
         run: |
           yum install -y devtoolset-9

--- a/.github/workflows/ci_centos7.yml
+++ b/.github/workflows/ci_centos7.yml
@@ -30,8 +30,9 @@ jobs:
     steps:
       - name: Update mirrors
         run: |
-          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
       - name: Update Dependencies
         run: |
@@ -47,8 +48,9 @@ jobs:
 
       - name: Update mirrors again because why not
         run: |
-          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
       - name: Install Dependencies 3
         run: |

--- a/.github/workflows/ci_centos7.yml
+++ b/.github/workflows/ci_centos7.yml
@@ -33,6 +33,7 @@ jobs:
           sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
           sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
           sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+          sed -i s/mirrorlist.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 
       - name: Update Dependencies
         run: |

--- a/.github/workflows/ci_centos7.yml
+++ b/.github/workflows/ci_centos7.yml
@@ -30,10 +30,8 @@ jobs:
     steps:
       - name: Update mirrors
         run: |
-          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-          sed -i s/mirrorlist.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
       - name: Update Dependencies
         run: |

--- a/.github/workflows/ci_centos7.yml
+++ b/.github/workflows/ci_centos7.yml
@@ -28,14 +28,26 @@ jobs:
     runs-on: ubuntu-latest
     container: 'centos:centos7'
     steps:
-      - name: Install Dependencies
+      - name: Update mirrors
         run: |
           sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
           sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
           sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+      - name: Update Dependencies
+        run: |
           yum update -y
+
+      - name: Install Dependencies 1
+        run: |
           yum install -y epel-release
+
+      - name: Install Dependencies 2
+        run: |
           yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils
+
+      - name: Install Dependencies 3
+        run: |
           yum install -y devtoolset-9
 
       - name: Setup cmake

--- a/.github/workflows/qa_pr_cpp_centos7.yml
+++ b/.github/workflows/qa_pr_cpp_centos7.yml
@@ -17,17 +17,41 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   clang-tidy:
     name: Clang-tidy CentOS
     runs-on: ubuntu-latest
     container: 'centos:centos7'
     steps:
-      - name: Install Dependancies
+      - name: Update mirrors
+        run: |
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+      - name: Update Dependencies
         run: |
           yum update -y
+
+      - name: Install Dependencies 1
+        run: |
           yum install -y epel-release
+
+      - name: Install Dependencies 2
+        run: |
           yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils
+
+      - name: Update mirrors again because why not
+        run: |
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+      - name: Install Dependencies 3
+        run: |
           yum install -y devtoolset-9
 
       - name: Setup cmake
@@ -120,14 +144,37 @@ jobs:
     runs-on: ubuntu-latest
     container: 'centos:centos7'
     steps:
-      - name: Install Dependencies
+      - name: Update mirrors
+        run: |
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+      - name: Update Dependencies
         run: |
           yum update -y
-          yum install -y epel-release
-          yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils
-          yum install -y devtoolset-9
-          yum install -y python3 python3-pip
 
+      - name: Install Dependencies 1
+        run: |
+          yum install -y epel-release
+
+      - name: Install Dependencies 2
+        run: |
+          yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils
+
+      - name: Update mirrors again because why not
+        run: |
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+      - name: Install Dependencies 3
+        run: |
+          yum install -y devtoolset-9
+
+      - name: Install Dependencies 4
+        run: |
+          yum install -y python3 python3-pip
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.13
@@ -216,11 +263,32 @@ jobs:
     needs: qa
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     steps:
-      - name: Install Dependencies
+      - name: Update mirrors
+        run: |
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+      - name: Update Dependencies
         run: |
           yum update -y
+
+      - name: Install Dependencies 1
+        run: |
           yum install -y epel-release
+
+      - name: Install Dependencies 2
+        run: |
           yum install -y git redhat-lsb-core make wget centos-release-scl scl-utils
+
+      - name: Update mirrors again because why not
+        run: |
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+      - name: Install Dependencies 3
+        run: |
           yum install -y devtoolset-9
 
       - name: Setup cmake


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Temporary bug fix

**What is the current behavior?**

- yum does not work anymore on CentOS container since the usual mirror has been discarded (CentOS has reached EOL)
- Node 16 is also deprecated

**What is the new behavior (if this is a feature change)?**
- Mirrors are changed
- Use of older Node versions is allowed now

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
Useful links:

- https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
- https://stackoverflow.com/questions/78692851/could-not-retrieve-mirrorlist-http-mirrorlist-centos-org-release-7arch-x86-6
- https://github.com/actions/checkout/issues/1809#issuecomment-2208202462