### PR TITLE
[IMG-2401] Add OPF_WITH_OVERLOAD computation type

### DIFF
--- a/docs/metrix.md
+++ b/docs/metrix.md
@@ -47,6 +47,7 @@ determines which kind of computation will be operated:
 - `LF` the LOAD FLOW mode is a basic network flow simulation, production and consumption are fixed and Metrix simulator returns the flow on the lines of the network.
 - `OPF_WITHOUT_REDISPATCHING` in this mode, Metrix simulator is allowed to use some actions (topological actions, use of phase tap changers, HVDC lines) to minimize constraints.
 - `OPF` in OPTIMAL POWER FLOW mode, Metrix simulator will leverage all available actions (that of the previous mode plus generator and load dispatching) to minimize constraints at best cost. If no solution is found, the program will exit with error code 1.
+- `OPF_WITH_OVERLOAD` in this OPTIMAL POWER FLOW mode, Metrix simulator works like in the previous mode. If no solution is found, the program returns overload results.
 
 All parameters are optional:
 ```groovy

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixComputationType.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixComputationType.java
@@ -14,7 +14,8 @@ public enum MetrixComputationType {
     OPF(0),
     LF(1),
     OPF_WITHOUT_REDISPATCHING(2),
-    UNKNOWN(3);
+    OPF_WITH_OVERLOAD(3),
+    UNKNOWN(4);
 
     private final int type;
 

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixComputationType.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixComputationType.java
@@ -14,8 +14,7 @@ public enum MetrixComputationType {
     OPF(0),
     LF(1),
     OPF_WITHOUT_REDISPATCHING(2),
-    OPF_WITH_OVERLOAD(3),
-    UNKNOWN(4);
+    OPF_WITH_OVERLOAD(3);
 
     private final int type;
 

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixParametersTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixParametersTest.java
@@ -16,21 +16,26 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class MetrixParametersTest {
 
-    @Test
-    void getSetTest() {
-        MetrixParameters p = new MetrixParameters(
-            MetrixComputationType.OPF_WITHOUT_REDISPATCHING,
-            10f,
-            1000);
-        assertEquals(MetrixComputationType.OPF_WITHOUT_REDISPATCHING, p.getComputationType());
-        assertEquals(10f, p.getLossFactor(), 0f);
-        assertEquals(1000, p.getNominalU());
+    private void checkOptionalIntParametersAreNotPresent(MetrixParameters p) {
+        assertFalse(p.getOptionalMaxSolverTime().isPresent());
+        assertFalse(p.getOptionalLossNbRelaunch().isPresent());
+        assertFalse(p.getOptionalLossThreshold().isPresent());
+        assertFalse(p.getOptionalNbMaxIteration().isPresent());
+        assertFalse(p.getOptionalNbMaxCurativeAction().isPresent());
+        assertFalse(p.getOptionalNbMaxLostLoadDetailedResults().isPresent());
+        assertFalse(p.getOptionalGapVariableCost().isPresent());
+        assertFalse(p.getOptionalNbThreatResults().isPresent());
+        assertFalse(p.getOptionalRedispatchingCostOffset().isPresent());
+        assertFalse(p.getOptionalAdequacyCostOffset().isPresent());
+        assertFalse(p.getOptionalCurativeRedispatchingLimit().isPresent());
+    }
+
+    private void checkOptionalParametersAreNotPresent(MetrixParameters p) {
         assertFalse(p.isWithGridCost().isPresent());
         assertFalse(p.isPreCurativeResults().isPresent());
         assertFalse(p.isOutagesBreakingConnexity().isPresent());
         assertFalse(p.isRemedialActionsBreakingConnexity().isPresent());
         assertFalse(p.isAnalogousRemedialActionDetection().isPresent());
-        assertFalse(p.isPropagateBranchTripping());
         assertFalse(p.isWithAdequacyResults().isPresent());
         assertFalse(p.isWithRedispatchingResults().isPresent());
         assertFalse(p.isMarginalVariationsOnBranches().isPresent());
@@ -44,18 +49,82 @@ class MetrixParametersTest {
         assertFalse(p.getOptionalCurativeLossOfLoadCost().isPresent());
         assertFalse(p.getOptionalCurativeLossOfGenerationCost().isPresent());
         assertFalse(p.getOptionalContingenciesProbability().isPresent());
-        assertFalse(p.getOptionalMaxSolverTime().isPresent());
-        assertFalse(p.getOptionalLossNbRelaunch().isPresent());
-        assertFalse(p.getOptionalLossThreshold().isPresent());
-        assertFalse(p.getOptionalNbMaxIteration().isPresent());
-        assertFalse(p.getOptionalNbMaxCurativeAction().isPresent());
-        assertFalse(p.getOptionalNbMaxLostLoadDetailedResults().isPresent());
-        assertFalse(p.getOptionalGapVariableCost().isPresent());
-        assertFalse(p.getOptionalNbThreatResults().isPresent());
-        assertFalse(p.getOptionalRedispatchingCostOffset().isPresent());
-        assertFalse(p.getOptionalAdequacyCostOffset().isPresent());
-        assertFalse(p.getOptionalCurativeRedispatchingLimit().isPresent());
         assertFalse(p.isWithLostLoadDetailedResultsOnContingency().isPresent());
+    }
+
+    @Test
+    void defaultParametersTest() {
+        MetrixParameters p = new MetrixParameters();
+        assertEquals(MetrixComputationType.LF, p.getComputationType());
+        assertEquals(0f, p.getLossFactor(), 0f);
+        assertEquals(100, p.getNominalU());
+        checkOptionalIntParametersAreNotPresent(p);
+        checkOptionalParametersAreNotPresent(p);
+        assertFalse(p.isPropagateBranchTripping());
+    }
+
+    @Test
+    void mandatoryParametersTest() {
+        MetrixParameters p = new MetrixParameters(
+            MetrixComputationType.OPF_WITHOUT_REDISPATCHING,
+            10f,
+            1000);
+
+        assertEquals(MetrixComputationType.OPF_WITHOUT_REDISPATCHING, p.getComputationType());
+        assertEquals(10f, p.getLossFactor(), 0f);
+        assertEquals(1000, p.getNominalU());
+
+        assertEquals(p, p.setComputationType(MetrixComputationType.OPF));
+        assertEquals(MetrixComputationType.OPF, p.getComputationType());
+
+        assertEquals(p, p.setComputationType(MetrixComputationType.LF));
+        assertEquals(MetrixComputationType.LF, p.getComputationType());
+
+        assertEquals(p, p.setComputationType(MetrixComputationType.OPF_WITH_OVERLOAD));
+        assertEquals(MetrixComputationType.OPF_WITH_OVERLOAD, p.getComputationType());
+
+        assertEquals(p, p.setComputationType(MetrixComputationType.OPF_WITHOUT_REDISPATCHING));
+        assertEquals(MetrixComputationType.OPF_WITHOUT_REDISPATCHING, p.getComputationType());
+
+        assertEquals(p, p.setLossFactor(20f));
+        assertEquals(20f, p.getLossFactor(), 0f);
+
+        assertEquals(p, p.setNominalU(37));
+        assertEquals(37, p.getNominalU());
+    }
+
+    @Test
+    void optionalIntParametersTest() {
+        MetrixParameters p = new MetrixParameters();
+
+        p.setMaxSolverTime(-1)
+            .setLossNbRelaunch(2)
+            .setLossThreshold(504)
+            .setNbMaxIteration(3)
+            .setNbMaxCurativeAction(4)
+            .setNbMaxLostLoadDetailedResults(5)
+            .setGapVariableCost(10000)
+            .setNbThreatResults(2)
+            .setRedispatchingCostOffset(50)
+            .setAdequacyCostOffset(4)
+            .setCurativeRedispatchingLimit(1500);
+
+        assertEquals(-1, p.getOptionalMaxSolverTime().getAsInt());
+        assertEquals(2, p.getOptionalLossNbRelaunch().getAsInt());
+        assertEquals(504, p.getOptionalLossThreshold().getAsInt());
+        assertEquals(3, p.getOptionalNbMaxIteration().getAsInt());
+        assertEquals(4, p.getOptionalNbMaxCurativeAction().getAsInt());
+        assertEquals(5, p.getOptionalNbMaxLostLoadDetailedResults().getAsInt());
+        assertEquals(10000, p.getOptionalGapVariableCost().getAsInt());
+        assertEquals(2, p.getOptionalNbThreatResults().getAsInt());
+        assertEquals(50, p.getOptionalRedispatchingCostOffset().getAsInt());
+        assertEquals(4, p.getOptionalAdequacyCostOffset().getAsInt());
+        assertEquals(1500, p.getOptionalCurativeRedispatchingLimit().getAsInt());
+    }
+
+    @Test
+    void optionalParametersTest() {
+        MetrixParameters p = new MetrixParameters();
 
         p.setWithGridCost(false)
             .setPreCurativeResults(true)
@@ -70,28 +139,18 @@ class MetrixParametersTest {
             .setLossDetailPerCountry(true)
             .setOverloadResultsOnly(true)
             .setShowAllTDandHVDCresults(true)
+            .setWithLostLoadDetailedResultsOnContingency(true)
             .setPstCostPenality(0.0001f)
             .setHvdcCostPenality(0.01f)
             .setLossOfLoadCost(9000f)
             .setCurativeLossOfLoadCost(1000f)
             .setCurativeLossOfGenerationCost(11000f)
-            .setContingenciesProbability(0.001f)
-            .setMaxSolverTime(-1)
-            .setLossNbRelaunch(2)
-            .setLossThreshold(504)
-            .setNbMaxIteration(3)
-            .setNbMaxCurativeAction(4)
-            .setNbMaxLostLoadDetailedResults(5)
-            .setGapVariableCost(10000)
-            .setNbThreatResults(2)
-            .setRedispatchingCostOffset(50)
-            .setAdequacyCostOffset(4)
-            .setCurativeRedispatchingLimit(1500)
-            .setWithLostLoadDetailedResultsOnContingency(true);
+            .setContingenciesProbability(0.001f);
 
         assertFalse(p.isWithGridCost().get());
         assertTrue(p.isPreCurativeResults().get());
         assertFalse(p.isOutagesBreakingConnexity().get());
+        assertFalse(p.isRemedialActionsBreakingConnexity().get());
         assertTrue(p.isAnalogousRemedialActionDetection().get());
         assertTrue(p.isPropagateBranchTripping());
         assertFalse(p.isWithAdequacyResults().get());
@@ -101,99 +160,13 @@ class MetrixParametersTest {
         assertTrue(p.isLossDetailPerCountry().get());
         assertTrue(p.isOverloadResultsOnly().get());
         assertTrue(p.isShowAllTDandHVDCresults().get());
-        assertEquals(2, p.getOptionalLossNbRelaunch().getAsInt());
-        assertEquals(504, p.getOptionalLossThreshold().getAsInt());
+        assertTrue(p.isWithLostLoadDetailedResultsOnContingency().get());
         assertEquals(0.0001f, p.getOptionalPstCostPenality().get(), 0f);
         assertEquals(0.01f, p.getOptionalHvdcCostPenality().get(), 0f);
         assertEquals(9000f, p.getOptionalLossOfLoadCost().get(), 0f);
+        assertEquals(1000f, p.getOptionalCurativeLossOfLoadCost().get(), 0f);
+        assertEquals(11000f, p.getOptionalCurativeLossOfGenerationCost().get(), 0f);
         assertEquals(0.001f, p.getOptionalContingenciesProbability().get(), 0f);
-        assertEquals(-1, p.getOptionalMaxSolverTime().getAsInt());
-        assertEquals(3, p.getOptionalNbMaxIteration().getAsInt());
-        assertEquals(4, p.getOptionalNbMaxCurativeAction().getAsInt());
-        assertEquals(5, p.getOptionalNbMaxLostLoadDetailedResults().getAsInt());
-        assertEquals(10000, p.getOptionalGapVariableCost().getAsInt());
-        assertEquals(2, p.getOptionalNbThreatResults().getAsInt());
-        assertEquals(4, p.getOptionalAdequacyCostOffset().getAsInt());
-        assertEquals(50, p.getOptionalRedispatchingCostOffset().getAsInt());
-        assertEquals(1500, p.getOptionalCurativeRedispatchingLimit().getAsInt());
-
-        assertEquals(p, p.setComputationType(MetrixComputationType.OPF));
-        assertEquals(MetrixComputationType.OPF, p.getComputationType());
-
-        assertEquals(p, p.setLossFactor(20f));
-        assertEquals(20f, p.getLossFactor(), 0f);
-
-        assertEquals(p, p.setNominalU(37));
-        assertEquals(37, p.getNominalU());
-
-        assertEquals(p, p.setWithGridCost(true));
-        assertTrue(p.isWithGridCost().get());
-
-        assertEquals(p, p.setPreCurativeResults(false));
-        assertFalse(p.isPreCurativeResults().get());
-
-        assertEquals(p, p.setOutagesBreakingConnexity(true));
-        assertTrue(p.isOutagesBreakingConnexity().get());
-
-        assertEquals(p, p.setAnalogousRemedialActionDetection(false));
-        assertFalse(p.isAnalogousRemedialActionDetection().get());
-
-        assertEquals(p, p.setPropagateBranchTripping(false));
-        assertFalse(p.isPropagateBranchTripping());
-
-        assertEquals(p, p.setWithAdequacyResults(true));
-        assertTrue(p.isWithAdequacyResults().get());
-
-        assertEquals(p, p.setMarginalVariationsOnBranches(false));
-        assertFalse(p.isMarginalVariationsOnBranches().get());
-
-        assertEquals(p, p.setMarginalVariationsOnHvdc(false));
-        assertFalse(p.isMarginalVariationsOnHvdc().get());
-
-        assertEquals(p, p.setLossDetailPerCountry(false));
-        assertFalse(p.isLossDetailPerCountry().get());
-
-        assertEquals(p, p.setWithLostLoadDetailedResultsOnContingency(true));
-        assertTrue(p.isWithLostLoadDetailedResultsOnContingency().get());
-
-        assertEquals(p, p.setMaxSolverTime(60));
-        assertEquals(60, p.getOptionalMaxSolverTime().getAsInt());
-
-        assertEquals(p, p.setLossNbRelaunch(5));
-        assertEquals(5, p.getOptionalLossNbRelaunch().getAsInt());
-
-        assertEquals(p, p.setLossThreshold(390));
-        assertEquals(390, p.getOptionalLossThreshold().getAsInt());
-
-        assertEquals(p, p.setPstCostPenality(0.02f));
-        assertEquals(0.02f, p.getOptionalPstCostPenality().get(), 0f);
-
-        assertEquals(p, p.setHvdcCostPenality(0.3f));
-        assertEquals(0.3f, p.getOptionalHvdcCostPenality().get(), 0f);
-
-        assertEquals(p, p.setLossOfLoadCost(8000f));
-        assertEquals(8000f, p.getOptionalLossOfLoadCost().get(), 0f);
-
-        assertEquals(p, p.setContingenciesProbability(0.003f));
-        assertEquals(0.003f, p.getOptionalContingenciesProbability().get(), 0f);
-
-        assertEquals(p, p.setNbMaxIteration(57));
-        assertEquals(57, p.getOptionalNbMaxIteration().getAsInt());
-
-        assertEquals(p, p.setNbMaxCurativeAction(33));
-        assertEquals(33, p.getOptionalNbMaxCurativeAction().getAsInt());
-
-        assertEquals(p, p.setNbMaxLostLoadDetailedResults(67));
-        assertEquals(67, p.getOptionalNbMaxLostLoadDetailedResults().getAsInt());
-
-        assertEquals(p, p.setGapVariableCost(15000));
-        assertEquals(15000, p.getOptionalGapVariableCost().getAsInt());
-
-        assertEquals(p, p.setNbThreatResults(10));
-        assertEquals(10, p.getOptionalNbThreatResults().getAsInt());
-
-        assertEquals(p, p.setCurativeRedispatchingLimit(-1));
-        assertEquals(-1, p.getOptionalCurativeRedispatchingLimit().getAsInt());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Metrix computation types are : OPF, LF, OPF_WITHOUT_REDISPATCHING


**What is the new behavior (if this is a feature change)?**
OPF_WITH_OVERLOAD computation type is added in order to obtain results even when all constraints cannot be resolved


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
