### PR TITLE
Fix issue with TapPosition when lowTapPosition > 0

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/dataGenerator/MetrixInputData.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/dataGenerator/MetrixInputData.java
@@ -475,7 +475,7 @@ public class MetrixInputData {
 
             MetrixPtcControlType mode = getMetrixPtcControlType(twt, index, dtlowran, dtuppran);
 
-            for (int pos = 0; pos < ptc.getStepCount(); pos++) {
+            for (int pos = ptc.getLowTapPosition(); pos < ptc.getLowTapPosition() + ptc.getStepCount(); pos++) {
                 dttapdep.add((float) ptc.getStep(pos).getAlpha());
             }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
If the network used has a TwoWindingsTransformer with a PhaseTapChanger with lowTapPosition different than 0, powsybl-metrix will crash during `MetrixInputData.writeTwoWindingsTransformer` because it tries to get the step at a non-existing position (either lower than the lowTapPosition or higher than the maximum).

**What is the new behavior (if this is a feature change)?**
The export will now start at the lowTapPosition.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
