### PR TITLE
Fix mapping tool NetworkPointWriter iIDM export performance

### DIFF
--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/NetworkPointWriter.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/NetworkPointWriter.java
@@ -19,6 +19,7 @@ import com.powsybl.iidm.serde.NetworkSerDe;
 import com.powsybl.metrix.mapping.common.MetrixIidmConfiguration;
 import com.powsybl.timeseries.TimeSeriesIndex;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -379,7 +380,7 @@ public class NetworkPointWriter extends DefaultTimeSeriesMapperObserver {
             // for the moment, it is not possible with PowSyBl to import with a suffix different from null ...
             suffix = null;
         }
-        try (OutputStream os = dataSource.newOutputStream(suffix, "xiidm", false)) {
+        try (OutputStream os = new BufferedOutputStream(dataSource.newOutputStream(suffix, "xiidm", false))) {
             ExportOptions exportOptions = new ExportOptions();
             exportOptions.setVersion(MetrixIidmConfiguration.load().getNetworkExportVersion());
             NetworkSerDe.write(network, exportOptions, os);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Poor performance of iidm export by mapping tool NetworkPointWriter


**What is the new behavior (if this is a feature change)?**
Expected iIDM export performance


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Kudos @olperr1 helping me in the fix ❤️ 

on ENTSOE RealGrid (25MB), with 3 time points / 3 iIDM export:
- 2 minutes before fix
- 7 seconds after fix
