### PR TITLE
Fix mapping tool iIDM export when network ID contains illegal characters

### DIFF
--- a/metrix-tools/src/main/java/com/powsybl/metrix/tools/MappingTool.java
+++ b/metrix-tools/src/main/java/com/powsybl/metrix/tools/MappingTool.java
@@ -27,6 +27,7 @@ import com.powsybl.tools.ToolRunningContext;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.commons.io.FileSystem;
 import org.codehaus.groovy.runtime.StackTraceUtils;
 
 import java.io.IOException;
@@ -317,7 +318,11 @@ public class MappingTool implements Tool {
             List<TimeSeriesMapperObserver> observers = new ArrayList<>(1);
             observers.add(balanceSummary);
             if (networkOutputDir != null) {
-                DataSource dataSource = DataSourceUtil.createDataSource(networkOutputDir, localParameters.network().getId(), null);
+                String cleanedNetworkId = localParameters.network().getId();
+                for (char c : FileSystem.getCurrent().getIllegalFileNameChars()) {
+                    cleanedNetworkId = cleanedNetworkId.replace(c, '_');
+                }
+                DataSource dataSource = DataSourceUtil.createDataSource(networkOutputDir, cleanedNetworkId, null);
                 observers.add(new NetworkPointWriter(localParameters.network(), dataSource));
             }
             if (equipmentTimeSeriesDir != null) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
mapping tool NetworkPointWriter uses the network ID in the file name.
IIDM export fails in case of special characters.
In particular CGMES files IDs are often in the form `urn:uuid:000....` and failing on Windows because of semicolon.


**What is the new behavior (if this is a feature change)?**
Illegal characters (OS dependent ...) are replaced by an underscore.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] No
