### PR TITLE
Adding doctrine costs configuration for redispatching, load shedding and losses

### DIFF
--- a/docs/metrix.md
+++ b/docs/metrix.md
@@ -233,6 +233,8 @@ If no generator is configured to be managed by Metrix, then all generators are i
 Note that Metrix will take into account the Pmin and Pmax values of generators (which can be modified through the mapping script).
 In the same way than most parameters, the value can be a fixed integer/float or a time series name.
 
+Doctrine costs can be defined for postprocessing purpose (up and down redispatching and costs timeseries)
+
 The syntax to define a managed generator is:
 
 ```groovy
@@ -303,6 +305,8 @@ for (g in network.generators) {
 
 Similarly to generators, loads can be adjusted in the OPF simulation (in preventive and curative mode), but only as a decrease. The cost in preventive action is fixed (default 13000 €/MWh) and can be modified in the global parameters with the keyword `lossOfLoadCost`. We can also override this value for specific loads. The specified cost will automatically be weighted with the contingency probability (default : 10^-3). We can also limit the maximum percentage of load shedding (in preventive and curative mode).
 
+Doctrine costs can be defined for postprocessing purpose (load shedding costs timeseries)
+
 Here is the corresponding syntax:
 ```groovy
 load(load_id) {
@@ -352,7 +356,9 @@ Control types:
 - `OPTIMIZED`: can optimize the p0 target in adequacy phase and preventive (and curative if contingencies were defined)
 - `FIXED`: the target p0 is fixed
 
-### LOSSES
+### Losses
+
+Doctrine costs can be defined for postprocessing purpose (global losses cost time series)
 
 ```groovy
 losses() {

--- a/docs/metrix.md
+++ b/docs/metrix.md
@@ -239,8 +239,10 @@ The syntax to define a managed generator is:
 generator(id) { // id of the generator which will be managed by Metrix 
   adequacyDownCosts 'ts_cost_down' // Cost of ramping down for the adequacy phase (here a time series name is used) 
   adequacyUpCosts 'ts_cost_up' // Cost of ramping up for the adequacy phase (here a time series name is used) 
-  redispatchingDownCosts 10 // Cost of ramping down (preventive) for the OPF simulation (here a fixed value is used)
-  redispatchingUpCosts 100 // Cost of ramping up (preventive) for the OPF simulation (here a fixed value is used)
+  redispatchingDownCosts 10 // Cost of ramping down for the OPF simulation (here a fixed value is used)
+  redispatchingUpCosts 100 // Cost of ramping up for the OPF simulation (here a fixed value is used)
+  redispatchingDownDoctrineCosts 10 // Doctrine cost of ramping down for the OPF simulation (fixed value or time series name)
+  redispatchingUpDoctrineCosts 100 // Doctrine cost of ramping up for the OPF simulation (fixed value or time series name)
   onContingencies 'a','b' // list of contingencies where Metrix can use this generator in (curative) remedial actions
 }
 ```
@@ -309,6 +311,8 @@ load(load_id) {
     curativeSheddingPercentage 10 // optional shedding max percentage for curative actions
     curativeSheddingCost 40 // optional cost for curative shedding action
     onContingencies 'a', 'b' // optional contingency upon which curative action are operated 
+    preventiveSheddingDoctrineCost 10000 // doctrine cost for preventive shedding action (fixed value or time series name)
+    curativeSheddingDoctrineCost 'ts_doctrine_cost' // doctrine cost for curative shedding action (fixed value or time series name)
 }
 ```
 
@@ -347,6 +351,14 @@ hvdc(id) {
 Control types:
 - `OPTIMIZED`: can optimize the p0 target in adequacy phase and preventive (and curative if contingencies were defined)
 - `FIXED`: the target p0 is fixed
+
+### LOSSES
+
+```groovy
+losses() {
+  costs 'ts_losses_cost' // Losses cost (fixed value or time series name)
+}
+```
 
 ### Monitored sections
 

--- a/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/GeneratorData.groovy
+++ b/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/GeneratorData.groovy
@@ -22,6 +22,8 @@ class GeneratorData {
     Object adequacyDownCosts
     Object redispatchingUpCosts
     Object redispatchingDownCosts
+    Object redispatchingUpDoctrineCosts
+    Object redispatchingDownDoctrineCosts
 
     void adequacyUpCosts(Object timeSeriesNames) {
         this.adequacyUpCosts = timeSeriesNames
@@ -39,12 +41,67 @@ class GeneratorData {
         this.redispatchingDownCosts = timeSeriesNames
     }
 
+    void redispatchingUpDoctrineCosts(Object timeSeriesNames) {
+        this.redispatchingUpDoctrineCosts = timeSeriesNames
+    }
+
+    void redispatchingDownDoctrineCosts(Object timeSeriesNames) {
+        this.redispatchingDownDoctrineCosts = timeSeriesNames
+    }
+
     void onContingencies(String[] contingencies) {
         this.onContingencies = contingencies
     }
 
     void onContingencies(List<String> onContingencies) {
         this.onContingencies = onContingencies
+    }
+
+    private static generatorForAdequacy(String id, GeneratorData spec, TimeSeriesMappingConfigLoader configLoader, MetrixDslData data, LogDslLoader logDslLoader) {
+        if (spec.adequacyUpCosts != null || spec.adequacyDownCosts != null) {
+            if (spec.adequacyUpCosts != null && spec.adequacyDownCosts != null) {
+                configLoader.addEquipmentTimeSeries(spec.adequacyDownCosts, MetrixVariable.OFF_GRID_COST_DOWN, id)
+                configLoader.addEquipmentTimeSeries(spec.adequacyUpCosts, MetrixVariable.OFF_GRID_COST_UP, id)
+                data.addGeneratorForAdequacy(id)
+            } else if (spec.adequacyUpCosts == null) {
+                logDslLoader.logDebug("generator %s is missing adequacy up-cost time-series to be properly configured", id)
+            } else {
+                logDslLoader.logDebug("generator %s is missing adequacy down-cost time-series to be properly configured", id)
+            }
+        }
+    }
+
+    private static boolean generatorForRedispatching(String id, GeneratorData spec, TimeSeriesMappingConfigLoader configLoader, MetrixDslData data, LogDslLoader logDslLoader) {
+        if (spec.redispatchingUpCosts != null || spec.redispatchingDownCosts != null) {
+            if (spec.redispatchingUpCosts != null && spec.redispatchingDownCosts != null) {
+                configLoader.addEquipmentTimeSeries(spec.redispatchingDownCosts, MetrixVariable.ON_GRID_COST_DOWN, id)
+                configLoader.addEquipmentTimeSeries(spec.redispatchingUpCosts, MetrixVariable.ON_GRID_COST_UP, id)
+                data.addGeneratorForRedispatching(id, spec.onContingencies)
+                return true
+            } else if (spec.redispatchingUpCosts == null) {
+                logDslLoader.logDebug("generator %s is missing redispatching up-cost time-series to be properly configured", id)
+            } else {
+                logDslLoader.logDebug("generator %s is missing redispatching down-cost time-series to be properly configured", id)
+            }
+        }
+        return false
+    }
+
+    private static generatorRedispatchingDoctrineCosts(String id, GeneratorData spec, TimeSeriesMappingConfigLoader configLoader, LogDslLoader logDslLoader) {
+        if (spec.redispatchingUpDoctrineCosts == null && spec.redispatchingDownDoctrineCosts == null) {
+            logDslLoader.logWarn("generator %s is missing redispatching doctrine cost to be properly configured", id)
+            return
+        }
+        if (spec.redispatchingUpDoctrineCosts == null) {
+            logDslLoader.logWarn("generator %s is missing redispatching doctrine up cost to be properly configured", id)
+            return
+        }
+        if (spec.redispatchingDownDoctrineCosts == null) {
+            logDslLoader.logWarn("generator %s is missing redispatching doctrine down cost to be properly configured", id)
+            return
+        }
+        configLoader.addEquipmentTimeSeries(spec.redispatchingDownDoctrineCosts, MetrixVariable.ON_GRID_DOCTRINE_COST_DOWN, id)
+        configLoader.addEquipmentTimeSeries(spec.redispatchingUpDoctrineCosts, MetrixVariable.ON_GRID_DOCTRINE_COST_UP, id)
     }
 
     protected static generatorData(Closure closure, String id, Network network, TimeSeriesMappingConfigLoader configLoader, MetrixDslData data, LogDslLoader logDslLoader) {
@@ -57,27 +114,10 @@ class GeneratorData {
         GeneratorData spec = generatorData(closure)
 
         if (spec) {
-            if (spec.adequacyUpCosts != null || spec.adequacyDownCosts != null) {
-                if (spec.adequacyUpCosts != null && spec.adequacyDownCosts != null) {
-                    configLoader.addEquipmentTimeSeries(spec.adequacyDownCosts, MetrixVariable.OFF_GRID_COST_DOWN, id)
-                    configLoader.addEquipmentTimeSeries(spec.adequacyUpCosts, MetrixVariable.OFF_GRID_COST_UP, id)
-                    data.addGeneratorForAdequacy(id)
-                } else if (spec.adequacyUpCosts == null) {
-                    logDslLoader.logDebug("generator %s is missing adequacy up-cost time-series to be properly configured", id)
-                } else {
-                    logDslLoader.logDebug("generator %s is missing adequacy down-cost time-series to be properly configured", id)
-                }
-            }
-            if (spec.redispatchingUpCosts != null || spec.redispatchingDownCosts != null) {
-                if (spec.redispatchingUpCosts != null && spec.redispatchingDownCosts != null) {
-                    configLoader.addEquipmentTimeSeries(spec.redispatchingDownCosts, MetrixVariable.ON_GRID_COST_DOWN, id)
-                    configLoader.addEquipmentTimeSeries(spec.redispatchingUpCosts, MetrixVariable.ON_GRID_COST_UP, id)
-                    data.addGeneratorForRedispatching(id, spec.onContingencies)
-                } else if (spec.redispatchingUpCosts == null) {
-                    logDslLoader.logDebug("generator %s is missing redispatching up-cost time-series to be properly configured", id)
-                } else {
-                    logDslLoader.logDebug("generator %s is missing redispatching down-cost time-series to be properly configured", id)
-                }
+            generatorForAdequacy(id, spec, configLoader, data, logDslLoader)
+            boolean isGeneratorAvailableForRedispatching = generatorForRedispatching(id, spec, configLoader, data, logDslLoader)
+            if (isGeneratorAvailableForRedispatching) {
+                generatorRedispatchingDoctrineCosts(id, spec, configLoader, logDslLoader)
             }
         }
     }

--- a/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/GeneratorData.groovy
+++ b/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/GeneratorData.groovy
@@ -57,6 +57,9 @@ class GeneratorData {
         this.onContingencies = onContingencies
     }
 
+    /**
+     * Set the generator available for adequacy when up and down adequacy costs are defined
+     */
     private static generatorForAdequacy(String id, GeneratorData spec, TimeSeriesMappingConfigLoader configLoader, MetrixDslData data, LogDslLoader logDslLoader) {
         if (spec.adequacyUpCosts != null || spec.adequacyDownCosts != null) {
             if (spec.adequacyUpCosts != null && spec.adequacyDownCosts != null) {
@@ -71,6 +74,9 @@ class GeneratorData {
         }
     }
 
+    /**
+     * Set the generator available for redispatching when up and down redispatching costs are defined
+     */
     private static boolean generatorForRedispatching(String id, GeneratorData spec, TimeSeriesMappingConfigLoader configLoader, MetrixDslData data, LogDslLoader logDslLoader) {
         if (spec.redispatchingUpCosts != null || spec.redispatchingDownCosts != null) {
             if (spec.redispatchingUpCosts != null && spec.redispatchingDownCosts != null) {
@@ -87,6 +93,9 @@ class GeneratorData {
         return false
     }
 
+    /**
+     * Define up and down redispatching doctrine costs when generator is available for redispatching
+     */
     private static generatorRedispatchingDoctrineCosts(String id, GeneratorData spec, TimeSeriesMappingConfigLoader configLoader, LogDslLoader logDslLoader) {
         if (spec.redispatchingUpDoctrineCosts == null && spec.redispatchingDownDoctrineCosts == null) {
             logDslLoader.logWarn("generator %s is missing redispatching doctrine cost to be properly configured", id)

--- a/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/LoadData.groovy
+++ b/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/LoadData.groovy
@@ -20,8 +20,10 @@ class LoadData {
     List<String> onContingencies
     Integer preventiveSheddingPercentage
     Float preventiveSheddingCost
+    Object preventiveSheddingDoctrineCost
     Integer curativeSheddingPercentage
     Object curativeSheddingCost
+    Object curativeSheddingDoctrineCost
 
     void preventiveSheddingPercentage(int percent) {
         this.preventiveSheddingPercentage = percent
@@ -29,6 +31,10 @@ class LoadData {
 
     void preventiveSheddingCost(float loadSheddingCost) {
         this.preventiveSheddingCost = loadSheddingCost
+    }
+
+    void preventiveSheddingDoctrineCost(Object timeSeriesNames) {
+        this.preventiveSheddingDoctrineCost = timeSeriesNames
     }
 
     void curativeSheddingPercentage(int percent) {
@@ -39,12 +45,64 @@ class LoadData {
         this.curativeSheddingCost = timeSeriesName
     }
 
+    void curativeSheddingDoctrineCost(Object timeSeriesName) {
+        this.curativeSheddingDoctrineCost = timeSeriesName
+    }
+
     void onContingencies(String[] onContingencies) {
         this.onContingencies = onContingencies
     }
 
     void onContingencies(List<String> onContingencies) {
         this.onContingencies = onContingencies
+    }
+
+    private static boolean loadForPreventiveShedding(String id, LoadData loadSpec, MetrixDslData data, LogDslLoader logDslLoader) {
+        if (loadSpec.preventiveSheddingPercentage != null) {
+            if (loadSpec.preventiveSheddingPercentage > 100 || loadSpec.preventiveSheddingPercentage < 0) {
+                logDslLoader.logWarn("preventive shedding percentage for load %s is not valid", id)
+            } else {
+                data.addPreventiveLoad(id, loadSpec.preventiveSheddingPercentage)
+                if (loadSpec.preventiveSheddingCost != null) {
+                    data.addPreventiveLoadCost(id, loadSpec.preventiveSheddingCost)
+                }
+                return true
+            }
+        }
+        return false
+    }
+
+    private static void loadPreventiveSheddingDoctrineCosts(String id, LoadData loadSpec, TimeSeriesMappingConfigLoader configLoader, LogDslLoader logDslLoader) {
+        if (loadSpec.preventiveSheddingDoctrineCost == null) {
+            logDslLoader.logWarn("load %s is missing preventive shedding doctrine cost to be properly configured", id)
+            return
+        }
+        configLoader.addEquipmentTimeSeries(loadSpec.preventiveSheddingDoctrineCost, MetrixVariable.PREVENTIVE_DOCTRINE_COST_DOWN, id)
+    }
+
+    private static boolean loadForCurativeShedding(String id, LoadData loadSpec, TimeSeriesMappingConfigLoader configLoader, MetrixDslData data, LogDslLoader logDslLoader) {
+        if (loadSpec.curativeSheddingPercentage || loadSpec.curativeSheddingCost != null || loadSpec.onContingencies) {
+            if (loadSpec.curativeSheddingPercentage && loadSpec.curativeSheddingCost != null && loadSpec.onContingencies) {
+                if (loadSpec.curativeSheddingPercentage > 100 || loadSpec.curativeSheddingPercentage < 0) {
+                    logDslLoader.logWarn("curative shedding percentage for load %s is not valid", id)
+                } else {
+                    configLoader.addEquipmentTimeSeries(loadSpec.curativeSheddingCost, MetrixVariable.CURATIVE_COST_DOWN, id)
+                    data.addCurativeLoad(id, loadSpec.curativeSheddingPercentage, loadSpec.onContingencies)
+                    return true
+                }
+            } else {
+                logDslLoader.logWarn("configuration error for load %s : curative costs, percentage and contingencies list must be set altogether", id)
+            }
+        }
+        return false
+    }
+
+    private static void loadCurativeSheddingDoctrineCosts(String id, LoadData loadSpec, TimeSeriesMappingConfigLoader configLoader, LogDslLoader logDslLoader) {
+        if (loadSpec.curativeSheddingDoctrineCost == null) {
+            logDslLoader.logWarn("load %s is missing curative shedding doctrine cost to be properly configured", id)
+            return
+        }
+        configLoader.addEquipmentTimeSeries(loadSpec.curativeSheddingDoctrineCost, MetrixVariable.CURATIVE_DOCTRINE_COST_DOWN, id)
     }
 
     protected static loadData(Closure closure, String id, Network network, TimeSeriesMappingConfigLoader configLoader, MetrixDslData data, LogDslLoader logDslLoader) {
@@ -56,28 +114,14 @@ class LoadData {
 
         LoadData loadSpec = loadData(closure)
 
-        if (loadSpec.preventiveSheddingPercentage != null) {
-            if (loadSpec.preventiveSheddingPercentage > 100 || loadSpec.preventiveSheddingPercentage < 0) {
-                logDslLoader.logWarn("preventive shedding percentage for load %s is not valid", id)
-            } else {
-                data.addPreventiveLoad(id, loadSpec.preventiveSheddingPercentage)
-                if (loadSpec.preventiveSheddingCost != null) {
-                    data.addPreventiveLoadCost(id, loadSpec.preventiveSheddingCost)
-                }
-            }
+        boolean isLoadAvailableForPreventiveShedding = loadForPreventiveShedding(id, loadSpec, data, logDslLoader)
+        if (isLoadAvailableForPreventiveShedding) {
+            loadPreventiveSheddingDoctrineCosts(id, loadSpec, configLoader, logDslLoader)
         }
 
-        if (loadSpec.curativeSheddingPercentage || loadSpec.curativeSheddingCost != null || loadSpec.onContingencies) {
-            if (loadSpec.curativeSheddingPercentage && loadSpec.curativeSheddingCost != null && loadSpec.onContingencies) {
-                if (loadSpec.curativeSheddingPercentage > 100 || loadSpec.curativeSheddingPercentage < 0) {
-                    logDslLoader.logWarn("curative shedding percentage for load %s is not valid", id)
-                } else {
-                    configLoader.addEquipmentTimeSeries(loadSpec.curativeSheddingCost, MetrixVariable.CURATIVE_COST_DOWN, id)
-                    data.addCurativeLoad(id, loadSpec.curativeSheddingPercentage, loadSpec.onContingencies)
-                }
-            } else {
-                logDslLoader.logWarn("configuration error for load %s : curative costs, percentage and contingencies list must be set altogether", id)
-            }
+        boolean isLoadAvailableForCurativeShedding = loadForCurativeShedding(id, loadSpec, configLoader, data, logDslLoader)
+        if (isLoadAvailableForCurativeShedding) {
+            loadCurativeSheddingDoctrineCosts(id, loadSpec, configLoader, logDslLoader)
         }
     }
 

--- a/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/LossesData.groovy
+++ b/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/LossesData.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.metrix.integration
+
+import com.powsybl.iidm.network.Network
+import com.powsybl.metrix.mapping.LogDslLoader
+import com.powsybl.metrix.mapping.TimeSeriesMappingConfigLoader
+
+/**
+ * @author Marianne Funfrock {@literal <marianne.funfrock at rte-france.com>}
+ */
+class LossesData {
+
+    Object costs
+
+    void costs(Object timeSeriesNames) {
+        this.costs = timeSeriesNames
+    }
+
+    private static lossesDoctrineCosts(String id, LossesData spec, TimeSeriesMappingConfigLoader configLoader, LogDslLoader logDslLoader) {
+        if (spec.costs != null) {
+            configLoader.addEquipmentTimeSeries(spec.costs, MetrixVariable.LOSSES_DOCTRINE_COST, id)
+        }
+    }
+
+    protected static lossesData(Closure closure, Network network, TimeSeriesMappingConfigLoader configLoader, LogDslLoader logDslLoader) {
+        LossesData spec = lossesData(closure)
+        if (spec) {
+            lossesDoctrineCosts(network.getId(), spec, configLoader, logDslLoader)
+        }
+    }
+
+    protected static LossesData lossesData(Closure closure) {
+        def cloned = closure.clone()
+        LossesData spec = new LossesData()
+        cloned.delegate = spec
+        cloned()
+        spec
+    }
+}

--- a/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/MetrixDslDataLoader.groovy
+++ b/metrix-integration/src/main/groovy/com/powsybl/metrix/integration/MetrixDslDataLoader.groovy
@@ -34,6 +34,7 @@ import static LoadsBindingData.loadsBindingData
 import static ParametersData.parametersData
 import static PhaseShifterData.phaseShifterData
 import static SectionMonitoringData.sectionMonitoringData
+import static LossesData.lossesData
 
 /**
  * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
@@ -175,6 +176,11 @@ class MetrixDslDataLoader {
         // specific contingency list
         binding.contingencies = { Closure<Void> closure ->
             contingenciesData(closure, data, logDslLoader)
+        }
+
+        // losses
+        binding.losses = { Closure<Void> closure ->
+            lossesData(closure, network, loader, logDslLoader)
         }
     }
 

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixVariable.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixVariable.java
@@ -25,6 +25,8 @@ public enum MetrixVariable implements MappingVariable {
     OFF_GRID_COST_UP("offGridCostUp"),
     ON_GRID_COST_DOWN("onGridCostDown"),
     ON_GRID_COST_UP("onGridCostUp"),
+    ON_GRID_DOCTRINE_COST_DOWN("onGridDoctrineCostDown"),
+    ON_GRID_DOCTRINE_COST_UP("onGridDoctrineCostUp"),
     ANALYSIS_THRESHOLD_N("analysisThresholdN"),
     ANALYSIS_THRESHOLD_NK("analysisThresholdNk"),
     ANALYSIS_THRESHOLD_N_END_OR("analysisThresholdNEndOr"),
@@ -39,7 +41,10 @@ public enum MetrixVariable implements MappingVariable {
     THRESHOLD_NK_END_OR("thresholdNkEndOr"),
     THRESHOLD_ITAM_END_OR("thresholdITAMEndOr"),
     THRESHOLD_ITAM_NK_END_OR("thresholdITAMNkEndOr"),
-    CURATIVE_COST_DOWN("curativeCostDown");
+    CURATIVE_COST_DOWN("curativeCostDown"),
+    PREVENTIVE_DOCTRINE_COST_DOWN("preventiveDoctrineCostDown"),
+    CURATIVE_DOCTRINE_COST_DOWN("curativeDoctrineCostDown"),
+    LOSSES_DOCTRINE_COST("lossesDoctrineCost");
 
     protected static final String NAME = "metrix";
 

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderDoctrineCostTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderDoctrineCostTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,7 +50,7 @@ class MetrixDslDataLoaderDoctrineCostTest {
         fileSystem = Jimfs.newFileSystem(Configuration.unix());
         dslFile = fileSystem.getPath("/test.dsl");
         mappingFile = fileSystem.getPath("/mapping.dsl");
-        network = NetworkSerDe.read(getClass().getResourceAsStream("/simpleNetwork.xml"));
+        network = NetworkSerDe.read(Objects.requireNonNull(getClass().getResourceAsStream("/simpleNetwork.xml")));
 
         // Create mapping file for use in all tests
         try (Writer writer = Files.newBufferedWriter(mappingFile, StandardCharsets.UTF_8)) {

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderDoctrineCostTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderDoctrineCostTest.java
@@ -12,7 +12,8 @@ import com.google.common.jimfs.Jimfs;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.serde.NetworkSerDe;
 import com.powsybl.metrix.mapping.*;
-import com.powsybl.timeseries.*;
+import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
+import com.powsybl.timeseries.ReadOnlyTimeSeriesStoreCache;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 
-import static com.powsybl.commons.test.TestUtil.normalizeLineSeparator;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Marianne Funfrock {@literal <marianne.funfrock at rte-france.com>}
@@ -198,7 +198,7 @@ class MetrixDslDataLoaderDoctrineCostTest {
             MetrixDslDataLoader.load(dslFile, network, parameters, store, new TimeSeriesMappingConfig(), out);
         }
 
-        String output = normalizeLineSeparator(outputStream.toString());
+        String output = outputStream.toString();
         String expectedMessage = String.join(System.lineSeparator(),
             "WARNING;Metrix script;load FSSV.O11_L is missing preventive shedding doctrine cost to be properly configured",
             "WARNING;Metrix script;load FVALDI11_L is missing curative shedding doctrine cost to be properly configured",

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderDoctrineCostTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderDoctrineCostTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.metrix.integration;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.serde.NetworkSerDe;
+import com.powsybl.metrix.mapping.*;
+import com.powsybl.timeseries.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static com.powsybl.commons.test.TestUtil.normalizeLineSeparator;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Marianne Funfrock {@literal <marianne.funfrock at rte-france.com>}
+ */
+class MetrixDslDataLoaderDoctrineCostTest {
+
+    private FileSystem fileSystem;
+
+    private Path dslFile;
+
+    private Path mappingFile;
+
+    private Network network;
+
+    private final MetrixParameters parameters = new MetrixParameters();
+
+    private final MappingParameters mappingParameters = MappingParameters.load();
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
+        dslFile = fileSystem.getPath("/test.dsl");
+        mappingFile = fileSystem.getPath("/mapping.dsl");
+        network = NetworkSerDe.read(getClass().getResourceAsStream("/simpleNetwork.xml"));
+
+        // Create mapping file for use in all tests
+        try (Writer writer = Files.newBufferedWriter(mappingFile, StandardCharsets.UTF_8)) {
+            writer.write(String.join(System.lineSeparator(),
+                "timeSeries['ts1'] = 100",
+                "timeSeries['ts2'] = 200"
+            ));
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        fileSystem.close();
+    }
+
+    @Test
+    void testLoadShedding() throws IOException {
+
+        try (Writer writer = Files.newBufferedWriter(dslFile, StandardCharsets.UTF_8)) {
+            writer.write(String.join(System.lineSeparator(),
+                "def contingenciesList = network.branches.collect()",
+                "load('FSSV.O11_L') {",
+                "   preventiveSheddingPercentage 30",
+                "   preventiveSheddingDoctrineCost 12000",
+                "}",
+                "load('FVALDI11_L') {",
+                "   curativeSheddingPercentage 10",
+                "   curativeSheddingCost 15000",
+                "   curativeSheddingDoctrineCost 10000",
+                "   onContingencies contingenciesList",
+                "}",
+                "load('FVALDI11_L2') {",
+                "   preventiveSheddingPercentage 30",
+                "   preventiveSheddingDoctrineCost 'ts1'",
+                "}",
+                "load('FVERGE11_L') {",
+                "   curativeSheddingPercentage 10",
+                "   curativeSheddingCost 15000",
+                "   curativeSheddingDoctrineCost 'ts2'",
+                "   onContingencies contingenciesList",
+                "}"));
+        }
+
+        ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
+        TimeSeriesMappingConfig mappingConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
+        MetrixDslDataLoader.load(dslFile, network, parameters, store, mappingConfig);
+
+        assertEquals("12000", mappingConfig.getEquipmentToTimeSeries().get(new MappingKey(MetrixVariable.PREVENTIVE_DOCTRINE_COST_DOWN, "FSSV.O11_L")));
+        assertEquals("ts1", mappingConfig.getEquipmentToTimeSeries().get(new MappingKey(MetrixVariable.PREVENTIVE_DOCTRINE_COST_DOWN, "FVALDI11_L2")));
+
+        assertEquals(Set.of(new MappingKey(MetrixVariable.PREVENTIVE_DOCTRINE_COST_DOWN, "FSSV.O11_L")), mappingConfig.getTimeSeriesToEquipment().get("12000"));
+        assertEquals(Set.of(new MappingKey(MetrixVariable.PREVENTIVE_DOCTRINE_COST_DOWN, "FVALDI11_L2")), mappingConfig.getTimeSeriesToEquipment().get("ts1"));
+
+        assertEquals("10000", mappingConfig.getEquipmentToTimeSeries().get(new MappingKey(MetrixVariable.CURATIVE_DOCTRINE_COST_DOWN, "FVALDI11_L")));
+        assertEquals("ts2", mappingConfig.getEquipmentToTimeSeries().get(new MappingKey(MetrixVariable.CURATIVE_DOCTRINE_COST_DOWN, "FVERGE11_L")));
+
+        assertEquals(Set.of(new MappingKey(MetrixVariable.CURATIVE_DOCTRINE_COST_DOWN, "FVALDI11_L")), mappingConfig.getTimeSeriesToEquipment().get("10000"));
+        assertEquals(Set.of(new MappingKey(MetrixVariable.CURATIVE_DOCTRINE_COST_DOWN, "FVERGE11_L")), mappingConfig.getTimeSeriesToEquipment().get("ts2"));
+    }
+
+    @Test
+    void testGeneratorRedispatching() throws IOException {
+
+        try (Writer writer = Files.newBufferedWriter(dslFile, StandardCharsets.UTF_8)) {
+            writer.write(String.join(System.lineSeparator(),
+                "generator('FSSV.O11_G') {",
+                "    redispatchingDownCosts (-10)",
+                "    redispatchingUpCosts 100",
+                "    redispatchingUpDoctrineCosts 50",
+                "    redispatchingDownDoctrineCosts 200",
+                "}",
+                "generator('FSSV.O12_G') {",
+                "    redispatchingDownCosts (-10)",
+                "    redispatchingUpCosts 100",
+                "    redispatchingUpDoctrineCosts 'ts1'",
+                "    redispatchingDownDoctrineCosts 'ts2'",
+                "}"));
+        }
+
+        ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
+        TimeSeriesMappingConfig mappingConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
+        MetrixDslDataLoader.load(dslFile, network, parameters, store, mappingConfig);
+
+        assertEquals("50", mappingConfig.getEquipmentToTimeSeries().get(new MappingKey(MetrixVariable.ON_GRID_DOCTRINE_COST_UP, "FSSV.O11_G")));
+        assertEquals("200", mappingConfig.getEquipmentToTimeSeries().get(new MappingKey(MetrixVariable.ON_GRID_DOCTRINE_COST_DOWN, "FSSV.O11_G")));
+        assertEquals("ts1", mappingConfig.getEquipmentToTimeSeries().get(new MappingKey(MetrixVariable.ON_GRID_DOCTRINE_COST_UP, "FSSV.O12_G")));
+        assertEquals("ts2", mappingConfig.getEquipmentToTimeSeries().get(new MappingKey(MetrixVariable.ON_GRID_DOCTRINE_COST_DOWN, "FSSV.O12_G")));
+
+        assertEquals(Set.of(new MappingKey(MetrixVariable.ON_GRID_DOCTRINE_COST_UP, "FSSV.O11_G")), mappingConfig.getTimeSeriesToEquipment().get("50"));
+        assertEquals(Set.of(new MappingKey(MetrixVariable.ON_GRID_DOCTRINE_COST_DOWN, "FSSV.O11_G")), mappingConfig.getTimeSeriesToEquipment().get("200"));
+        assertEquals(Set.of(new MappingKey(MetrixVariable.ON_GRID_DOCTRINE_COST_UP, "FSSV.O12_G")), mappingConfig.getTimeSeriesToEquipment().get("ts1"));
+        assertEquals(Set.of(new MappingKey(MetrixVariable.ON_GRID_DOCTRINE_COST_DOWN, "FSSV.O12_G")), mappingConfig.getTimeSeriesToEquipment().get("ts2"));
+    }
+
+    @Test
+    void testLosses() throws IOException {
+
+        try (Writer writer = Files.newBufferedWriter(dslFile, StandardCharsets.UTF_8)) {
+            writer.write(String.join(System.lineSeparator(),
+                    "losses() {",
+                    "    costs 'ts1'",
+                    "}"));
+        }
+
+        ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
+        TimeSeriesMappingConfig mappingConfig = new TimeSeriesDslLoader(mappingFile).load(network, mappingParameters, store, new DataTableStore(), null);
+        MetrixDslDataLoader.load(dslFile, network, parameters, store, mappingConfig);
+
+        assertEquals("ts1", mappingConfig.getEquipmentToTimeSeries().get(new MappingKey(MetrixVariable.LOSSES_DOCTRINE_COST, "SimpleNetworkWithReducedThresholds")));
+        assertEquals(Set.of(new MappingKey(MetrixVariable.LOSSES_DOCTRINE_COST, "SimpleNetworkWithReducedThresholds")), mappingConfig.getTimeSeriesToEquipment().get("ts1"));
+    }
+
+    @Test
+    void testDoctrineCostIsMissing() throws IOException {
+
+        try (Writer writer = Files.newBufferedWriter(dslFile, StandardCharsets.UTF_8)) {
+            writer.write(String.join(System.lineSeparator(),
+                "def contingenciesList = network.branches.collect()",
+                "load('FSSV.O11_L') {",
+                "   preventiveSheddingPercentage 30",
+                "}",
+                "load('FVALDI11_L') {",
+                "   curativeSheddingPercentage 10",
+                "   curativeSheddingCost 15000",
+                "   onContingencies contingenciesList",
+                "}",
+                "generator('FSSV.O11_G') {",
+                "    redispatchingDownCosts 10",
+                "    redispatchingUpCosts 20",
+                "}",
+                "generator('FSSV.O12_G') {",
+                "    redispatchingDownCosts 10",
+                "    redispatchingUpCosts 20",
+                "    redispatchingDownDoctrineCosts 40",
+                "}",
+                "generator('FVALDI11_G') {",
+                "    redispatchingDownCosts 10",
+                "    redispatchingUpCosts 20",
+                "    redispatchingUpDoctrineCosts 30",
+                "}"));
+        }
+
+        ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (Writer out = new BufferedWriter(new OutputStreamWriter(outputStream))) {
+            MetrixDslDataLoader.load(dslFile, network, parameters, store, new TimeSeriesMappingConfig(), out);
+        }
+
+        String output = normalizeLineSeparator(outputStream.toString());
+        String expectedMessage = String.join(System.lineSeparator(),
+            "WARNING;Metrix script;load FSSV.O11_L is missing preventive shedding doctrine cost to be properly configured",
+            "WARNING;Metrix script;load FVALDI11_L is missing curative shedding doctrine cost to be properly configured",
+            "WARNING;Metrix script;generator FSSV.O11_G is missing redispatching doctrine cost to be properly configured",
+            "WARNING;Metrix script;generator FSSV.O12_G is missing redispatching doctrine up cost to be properly configured",
+            "WARNING;Metrix script;generator FVALDI11_G is missing redispatching doctrine down cost to be properly configured",
+            "");
+        assertEquals(expectedMessage, output);
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature

**What is the current behavior?**


**What is the new behavior (if this is a feature change)?**
In existing generator('id') configuration function, **redispatchingDownDoctrineCosts** and **redispatchingUpDoctrineCost** can be defined

In existing load('id') configuration function, **preventiveSheddingDoctrineCost** and **curativeSheddingDoctrineCost** can be defined

A new losses() configuration function is added with **costs** attribute.

These new attributes are defined with a value or a time series name.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
