### PR TITLE
Set job-specific permissions for fork-sonar workflow

### DIFF
--- a/.github/workflows/fork-sonar.yml
+++ b/.github/workflows/fork-sonar.yml
@@ -6,13 +6,7 @@ on:
     types:
       - completed
 
-permissions:
-  actions: write
-  checks: write
-  contents: read
-  issues: read
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
   java:
@@ -21,6 +15,13 @@ jobs:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: write
+      checks: write
+      contents: read
+      issues: read
+      pull-requests: write
+      statuses: write
     steps:
       - name: Download PR information
         uses: actions/github-script@v7


### PR DESCRIPTION
Replaces global permissions with job-specific ones for better security and clarity. This ensures permissions are only granted within the scope of the required job steps.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
CI improvement

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Permissions are set on the workflow level

**What is the new behavior (if this is a feature change)?**
Permissions are set on the job level

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
