### PR TITLE
Move TimeSeriesMetadataIndex to timeseries package

### DIFF
--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesMetadataIndex.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesMetadataIndex.java
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * SPDX-License-Identifier: MPL-2.0
  */
-package com.powsybl.metrix.mapping.exception;
+package com.powsybl.metrix.mapping.timeseries;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesMetadataIndexTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/TimeSeriesMetadataIndexTest.java
@@ -7,7 +7,6 @@
  */
 package com.powsybl.metrix.mapping.timeseries;
 
-import com.powsybl.metrix.mapping.exception.TimeSeriesMetadataIndex;
 import com.powsybl.timeseries.RegularTimeSeriesIndex;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Code quality

**What is the current behavior?**
`TimeSeriesMetadataIndex` class is in a package dedicated to exceptions

**What is the new behavior (if this is a feature change)?**
`TimeSeriesMetadataIndex` class is in a package dedicated to time series classes

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
The class `TimeSeriesMetadataIndex` has been moved from the package `com.powsybl.metrix.mapping.exception` to the package `com.powsybl.metrix.mapping.timeseries`.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
