### PR TITLE
Move TimeSeriesMappingException to exception package

### DIFF
--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixDslDataLoaderTest.java
@@ -19,7 +19,7 @@ import com.powsybl.metrix.mapping.MappingParameters;
 import com.powsybl.metrix.mapping.TimeSeriesDslLoader;
 import com.powsybl.metrix.mapping.TimeSeriesMappingConfig;
 import com.powsybl.metrix.mapping.TimeSeriesMappingConfigTableLoader;
-import com.powsybl.metrix.mapping.TimeSeriesMappingException;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStoreCache;
 import com.powsybl.timeseries.RegularTimeSeriesIndex;

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/EquipmentMappingData.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/EquipmentMappingData.groovy
@@ -8,6 +8,7 @@
 package com.powsybl.metrix.mapping
 
 import com.powsybl.iidm.network.Identifiable
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException
 import groovy.transform.CompileStatic
 
 /**

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/GeneratorGroupTsData.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/GeneratorGroupTsData.groovy
@@ -9,6 +9,7 @@ package com.powsybl.metrix.mapping
 
 import com.powsybl.iidm.network.Generator
 import com.powsybl.iidm.network.Identifiable
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException
 import groovy.transform.CompileStatic
 
 /**

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/IgnoreLimitsData.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/IgnoreLimitsData.groovy
@@ -7,6 +7,7 @@
  */
 package com.powsybl.metrix.mapping
 
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException
 import groovy.transform.CompileStatic
 
 /**

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/LoadGroupTsData.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/LoadGroupTsData.groovy
@@ -9,6 +9,7 @@ package com.powsybl.metrix.mapping
 
 import com.powsybl.iidm.network.Identifiable
 import com.powsybl.iidm.network.Load
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException
 import groovy.transform.CompileStatic
 
 /**

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/PlannedOutagesData.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/PlannedOutagesData.groovy
@@ -8,6 +8,7 @@
 package com.powsybl.metrix.mapping
 
 import com.powsybl.iidm.network.Identifiable
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStore
 import com.powsybl.timeseries.StringTimeSeries
 import groovy.transform.CompileStatic

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/MappingKeyNetworkValue.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/MappingKeyNetworkValue.java
@@ -9,6 +9,7 @@ package com.powsybl.metrix.mapping;
 
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.LoadDetail;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 
 import java.util.Objects;
 

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMapper.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMapper.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.extensions.HvdcAngleDroopActivePowerControl;
 import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRange;
 import com.powsybl.iidm.network.extensions.HvdcOperatorActivePowerRangeAdder;
 import com.powsybl.iidm.network.extensions.LoadDetail;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 import com.powsybl.metrix.mapping.log.*;
 import com.powsybl.metrix.mapping.timeseries.EquipmentTimeSeriesMap;
 import com.powsybl.metrix.mapping.timeseries.MappedEquipment;

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigChecker.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigChecker.java
@@ -7,6 +7,8 @@
  */
 package com.powsybl.metrix.mapping;
 
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
+
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigLoader.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigLoader.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Injection;
 import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
 import com.powsybl.timeseries.ast.FloatNodeCalc;
 import com.powsybl.timeseries.ast.NodeCalc;

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigTableLoader.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigTableLoader.java
@@ -9,6 +9,7 @@ package com.powsybl.metrix.mapping;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 import com.powsybl.timeseries.*;
 import com.powsybl.timeseries.ast.NodeCalc;
 import com.powsybl.timeseries.ast.TimeSeriesNames;

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/exception/TimeSeriesMappingException.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/exception/TimeSeriesMappingException.java
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * SPDX-License-Identifier: MPL-2.0
  */
-package com.powsybl.metrix.mapping;
+package com.powsybl.metrix.mapping.exception;
 
 /**
  * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/EquipmentTimeSeriesMap.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/EquipmentTimeSeriesMap.java
@@ -10,6 +10,7 @@ package com.powsybl.metrix.mapping.timeseries;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.metrix.mapping.*;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 import com.powsybl.timeseries.TimeSeriesTable;
 
 import java.util.ArrayList;

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/MappingKeyNetworkValueTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/MappingKeyNetworkValueTest.java
@@ -10,6 +10,7 @@ package com.powsybl.metrix.mapping;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.PhaseTapChanger;
 import com.powsybl.iidm.serde.NetworkSerDe;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesDslLoaderTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesDslLoaderTest.java
@@ -13,6 +13,7 @@ import com.google.common.jimfs.Jimfs;
 import com.powsybl.commons.io.table.TableFormatterConfig;
 import com.powsybl.commons.test.TestUtil;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 import com.powsybl.metrix.mapping.util.MappingTestNetwork;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStoreCache;

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMapperTest.java
@@ -10,6 +10,7 @@ package com.powsybl.metrix.mapping;
 import com.google.common.collect.Range;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 import com.powsybl.metrix.mapping.util.MappingTestNetwork;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStoreCache;

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigTableLoaderTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesMappingConfigTableLoaderTest.java
@@ -3,6 +3,7 @@ package com.powsybl.metrix.mapping;
 import com.google.common.collect.Range;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import com.powsybl.metrix.mapping.exception.TimeSeriesMappingException;
 import com.powsybl.metrix.mapping.timeseries.FileSystemTimeSeriesStore;
 import com.powsybl.timeseries.DoubleTimeSeries;
 import com.powsybl.timeseries.InfiniteTimeSeriesIndex;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Code quality

**What is the current behavior?**
`TimeSeriesMappingException` class is not in a package dedicated to exceptions

**What is the new behavior (if this is a feature change)?**
`TimeSeriesMappingException` class is in a package dedicated to exceptions

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
The class `TimeSeriesMappingException` has been moved from the package `com.powsybl.metrix.mapping` to the package `com.powsybl.metrix.mapping.exception`.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
