### PR TITLE
Remove deprecated methods

### DIFF
--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeSeriesStore.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeSeriesStore.java
@@ -182,23 +182,6 @@ public class FileSystemTimeSeriesStore implements ReadOnlyTimeSeriesStore {
     }
 
     /**
-     * Import a list of TimeSeries in the current FileSystemTimeSeriesStore
-     * @deprecated use {@link #importTimeSeries(List, int, ExistingFilePolicy)} instead
-     */
-    @Deprecated(since = "2.3.0")
-    public void importTimeSeries(List<TimeSeries> timeSeriesList, int version, boolean overwriteExisting, boolean append) {
-        ExistingFilePolicy existingFilePolicy;
-        if (append) {
-            existingFilePolicy = ExistingFilePolicy.APPEND;
-        } else if (overwriteExisting) {
-            existingFilePolicy = ExistingFilePolicy.OVERWRITE;
-        } else {
-            existingFilePolicy = ExistingFilePolicy.THROW_EXCEPTION;
-        }
-        importTimeSeries(timeSeriesList, version, existingFilePolicy);
-    }
-
-    /**
      * <p>Import a list of TimeSeries in the current FileSystemTimeSeriesStore.</p>
      * <p>If a file already exists for such TimeSeries, the new TimeSeries will be appended to it</p>
      */
@@ -445,16 +428,6 @@ public class FileSystemTimeSeriesStore implements ReadOnlyTimeSeriesStore {
                 LongStream.concat(extractTimesFromIndex(newIndex), extractTimesFromIndex(existingIndex)).toArray()
             );
         }
-    }
-
-    /**
-     * Import a list of TimeSeries in the current FileSystemTimeSeriesStore
-     * @deprecated use {@link #importTimeSeries(BufferedReader, ExistingFilePolicy)}  instead
-     */
-    @Deprecated(since = "2.3.0")
-    public void importTimeSeries(BufferedReader reader, boolean overwriteExisting, boolean append) {
-        Map<Integer, List<TimeSeries>> integerListMap = TimeSeries.parseCsv(reader, new TimeSeriesCsvConfig());
-        integerListMap.forEach((key, value) -> importTimeSeries(value, key, overwriteExisting, append));
     }
 
     /**

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeSeriesStoreTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/timeseries/FileSystemTimeSeriesStoreTest.java
@@ -75,29 +75,6 @@ class FileSystemTimeSeriesStoreTest {
     }
 
     @Test
-    @Deprecated(since = "2.3.0")
-    void testTsStoreDeprecatedMethod() throws IOException {
-        FileSystemTimeSeriesStore tsStore = new FileSystemTimeSeriesStore(resDir);
-        Set<String> emptyTimeSeriesNames = tsStore.getTimeSeriesNames(null);
-        assertThat(emptyTimeSeriesNames).isEmpty();
-
-        try (InputStream resourceAsStream = Objects.requireNonNull(FileSystemTimeSeriesStoreTest.class.getResourceAsStream("/testStore.csv"));
-             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(resourceAsStream))
-        ) {
-            tsStore.importTimeSeries(bufferedReader, true, false);
-        }
-
-        assertThat(tsStore.getTimeSeriesNames(null)).isNotEmpty();
-        assertThat(tsStore.getTimeSeriesNames(null)).containsExactlyInAnyOrder("BALANCE", "tsX");
-
-        assertTrue(tsStore.timeSeriesExists("BALANCE"));
-        assertFalse(tsStore.timeSeriesExists("tsY"));
-
-        assertEquals(Set.of(1), tsStore.getTimeSeriesDataVersions());
-        assertEquals(Set.of(1), tsStore.getTimeSeriesDataVersions("BALANCE"));
-    }
-
-    @Test
     void testTsStore() throws IOException {
         FileSystemTimeSeriesStore tsStore = new FileSystemTimeSeriesStore(resDir);
         Set<String> emptyTimeSeriesNames = tsStore.getTimeSeriesNames(null);
@@ -591,62 +568,6 @@ class FileSystemTimeSeriesStoreTest {
         IrregularTimeSeriesIndex storedIndex1 = (IrregularTimeSeriesIndex) storedTs1.getMetadata().getIndex();
         assertEquals(978303600000L, storedIndex1.getInstantAt(0).toEpochMilli());
         assertEquals(978332400000L, storedIndex1.getInstantAt(storedIndex1.getPointCount() - 1).toEpochMilli());
-    }
-
-    @Test
-    @Deprecated(since = "2.3.0")
-    void testDeprecatedImportTimeSeries() throws IOException {
-        // TimeSeriesStore
-        FileSystemTimeSeriesStore tsStore = new FileSystemTimeSeriesStore(resDir);
-
-        // TimeSeries indexes
-        Instant now = Instant.ofEpochMilli(978303600000L);
-        RegularTimeSeriesIndex index = RegularTimeSeriesIndex.create(now,
-            now.plus(2, ChronoUnit.HOURS),
-            Duration.ofHours(1));
-        RegularTimeSeriesIndex indexBis = RegularTimeSeriesIndex.create(now.plus(3, ChronoUnit.HOURS),
-            now.plus(5, ChronoUnit.HOURS),
-            Duration.ofHours(1));
-
-        // TimeSeries
-        StoredDoubleTimeSeries ts1 = TimeSeries.createDouble("ts1", index, 1d, 2d, 3d);
-        StoredDoubleTimeSeries ts2 = TimeSeries.createDouble("ts1", indexBis, 4d, 5d, 6d);
-
-        // Append the TimeSeries
-        tsStore.importTimeSeries(List.of(ts1), 1);
-        tsStore.importTimeSeries(List.of(ts2), 1, false, true);
-
-        // Assertions for Double
-        assertTrue(tsStore.getDoubleTimeSeries("ts1", 1).isPresent());
-        StoredDoubleTimeSeries storedTs1 = (StoredDoubleTimeSeries) tsStore.getDoubleTimeSeries("ts1", 1).get();
-        assertArrayEquals(new double[] {1d, 2d, 3d, 4d, 5d, 6d}, storedTs1.toArray());
-        assertEquals(2, storedTs1.getChunks().size());
-        assertInstanceOf(RegularTimeSeriesIndex.class, storedTs1.getMetadata().getIndex());
-        RegularTimeSeriesIndex storedIndex = (RegularTimeSeriesIndex) storedTs1.getMetadata().getIndex();
-        assertEquals(978303600000L, storedIndex.getStartTime());
-        assertEquals(978321600000L, storedIndex.getEndTime());
-        assertEquals(3600000L, storedIndex.getSpacing());
-
-        // Append the TimeSeries
-        tsStore.importTimeSeries(List.of(ts2), 1, true, false);
-
-        // Assertions for Double
-        assertTrue(tsStore.getDoubleTimeSeries("ts1", 1).isPresent());
-        storedTs1 = (StoredDoubleTimeSeries) tsStore.getDoubleTimeSeries("ts1", 1).get();
-        assertArrayEquals(new double[] {4d, 5d, 6d}, storedTs1.toArray());
-        assertEquals(1, storedTs1.getChunks().size());
-        assertInstanceOf(RegularTimeSeriesIndex.class, storedTs1.getMetadata().getIndex());
-        storedIndex = (RegularTimeSeriesIndex) storedTs1.getMetadata().getIndex();
-        assertEquals(978314400000L, storedIndex.getStartTime());
-        assertEquals(978321600000L, storedIndex.getEndTime());
-        assertEquals(3600000L, storedIndex.getSpacing());
-
-        // Fails since it already exists
-        List<TimeSeries> list = List.of(ts2);
-        PowsyblException exception = assertThrows(PowsyblException.class,
-            () -> tsStore.importTimeSeries(list, 1, false, false));
-        assertEquals("Timeserie ts1 already exist", exception.getMessage());
-
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Code quality

**What is the current behavior?**
Some old deprecated methods are still present

**What is the new behavior (if this is a feature change)?**
Methods deprecated since a long time are now removed

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
The following deprecated methods were removed:
- `importTimeSeries(List<TimeSeries> timeSeriesList, int version, boolean overwriteExisting, boolean append)`
- `importTimeSeries(BufferedReader reader, boolean overwriteExisting, boolean append)`


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
