### PR TITLE
Fix finding equipments id for which redispatching or load shedding metrix results exist

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/AbstractMetrix.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/AbstractMetrix.java
@@ -123,7 +123,7 @@ public abstract class AbstractMetrix {
 
             MetrixRunResult runResult = new MetrixRunResult();
             appLogger.log("[%s] Computing postprocessing timeseries", schemaName);
-            runResult.setPostProcessingTimeSeries(getPostProcessingTimeSeries(analysisResult.metrixDslData, analysisResult.mappingConfig, resultStore, nullableSchemaName));
+            runResult.setPostProcessingTimeSeries(getPostProcessingTimeSeries(analysisResult.metrixDslData, analysisResult.mappingConfig, analysisResult.contingencies, resultStore, nullableSchemaName));
             return runResult;
 
         } catch (IOException e) {

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixPostProcessingTimeSeries.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/MetrixPostProcessingTimeSeries.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.metrix.integration;
 
+import com.powsybl.contingency.Contingency;
 import com.powsybl.metrix.mapping.TimeSeriesMappingConfig;
 import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
 import com.powsybl.timeseries.TimeSeriesFilter;
@@ -31,8 +32,34 @@ public final class MetrixPostProcessingTimeSeries {
     private MetrixPostProcessingTimeSeries() {
     }
 
+    /**
+     * Applies a filter on allIds : id is kept if allTimeSeriesNames contains a String equals to 'prefix' + 'id'
+     * Search for each id of allIds list if there is a time series of (prefix + id) name
+     * @param allIds             list of equipment ids to filter
+     * @param allTimeSeriesNames all metrix results time series names
+     * @param prefix             prefix of metrix results time series names to keep
+     */
     public static List<String> findIdsToProcess(Set<String> allIds, Set<String> allTimeSeriesNames, String prefix) {
-        return allIds.stream().filter(id -> allTimeSeriesNames.stream().anyMatch(s -> s.startsWith(prefix + id))).toList();
+        return allIds.stream().filter(id -> allTimeSeriesNames.stream().anyMatch(s -> s.equals(prefix + id))).toList();
+    }
+
+    /**
+     * Applies a filter on allIds : id is kept if allTimeSeriesNames contains a String starting with 'prefix' + 'id' + '_'
+     * and followed by one element of contingencyIds
+     * For curative results only (redispatching and load shedding)
+     * @param allIds             list of equipment ids to filter
+     * @param allTimeSeriesNames all metrix results time series names
+     * @param prefix             prefix of metrix results time series names to keep
+     * @param contingencyIds     list of contingency ids
+     */
+    public static List<String> findIdsToProcess(Set<String> allIds, Set<String> allTimeSeriesNames, String prefix, Set<String> contingencyIds) {
+        return allIds.stream().filter(id -> {
+            String prefixAndId = prefix + id + "_";
+            return allTimeSeriesNames.stream().filter(tsName -> tsName.startsWith(prefixAndId)).anyMatch(s -> {
+                String contingencyId = s.substring(prefixAndId.length());
+                return contingencyIds.contains(contingencyId);
+            });
+        }).toList();
     }
 
     /**
@@ -44,6 +71,7 @@ public final class MetrixPostProcessingTimeSeries {
      */
     public static Map<String, NodeCalc> getPostProcessingTimeSeries(MetrixDslData dslData,
                                                                     TimeSeriesMappingConfig mappingConfig,
+                                                                    List<Contingency> contingencies,
                                                                     ReadOnlyTimeSeriesStore store,
                                                                     String nullableSchemaName) {
         if (dslData == null || mappingConfig == null) {
@@ -59,11 +87,11 @@ public final class MetrixPostProcessingTimeSeries {
         Map<String, NodeCalc> postProcessingTimeSeries = new HashMap<>(branchProcessing.createPostProcessingTimeSeries());
 
         // Generator
-        MetrixGeneratorPostProcessingTimeSeries generatorProcessing = new MetrixGeneratorPostProcessingTimeSeries(dslData, mappingConfig, allTimeSeriesNames, nullableSchemaName);
+        MetrixGeneratorPostProcessingTimeSeries generatorProcessing = new MetrixGeneratorPostProcessingTimeSeries(dslData, mappingConfig, contingencies, allTimeSeriesNames, nullableSchemaName);
         postProcessingTimeSeries.putAll(generatorProcessing.createPostProcessingTimeSeries());
 
         // Load
-        MetrixLoadPostProcessingTimeSeries loadProcessing = new MetrixLoadPostProcessingTimeSeries(dslData, mappingConfig, allTimeSeriesNames, nullableSchemaName);
+        MetrixLoadPostProcessingTimeSeries loadProcessing = new MetrixLoadPostProcessingTimeSeries(dslData, mappingConfig, contingencies, allTimeSeriesNames, nullableSchemaName);
         postProcessingTimeSeries.putAll(loadProcessing.createPostProcessingTimeSeries());
 
         // Losses

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixGeneratorPostProcessingTimeSeriesTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixGeneratorPostProcessingTimeSeriesTest.java
@@ -8,6 +8,8 @@
 package com.powsybl.metrix.integration;
 
 import com.google.common.collect.Sets;
+import com.powsybl.contingency.BranchContingency;
+import com.powsybl.contingency.Contingency;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.serde.NetworkSerDe;
 import com.powsybl.metrix.integration.dataGenerator.MetrixOutputData;
@@ -30,6 +32,7 @@ import org.threeten.extra.Interval;
 
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -124,8 +127,9 @@ class MetrixGeneratorPostProcessingTimeSeriesTest {
         TimeSeriesMappingConfig mappingConfig = new TimeSeriesMappingConfig();
         MetrixDslDataLoader metrixDslDataLoader = new MetrixDslDataLoader(metrixConfigurationScript);
         MetrixDslData dslData = metrixDslDataLoader.load(network, parameters, store, new DataTableStore(), mappingConfig, null);
+        Contingency contingency = new Contingency("cty", List.of(new BranchContingency("FP.AND1  FVERGE1  1")));
 
-        MetrixGeneratorPostProcessingTimeSeries generatorProcessing = new MetrixGeneratorPostProcessingTimeSeries(dslData, mappingConfig, metrixResultTimeSeries.getTimeSeriesNames(null), null);
+        MetrixGeneratorPostProcessingTimeSeries generatorProcessing = new MetrixGeneratorPostProcessingTimeSeries(dslData, mappingConfig, List.of(contingency), metrixResultTimeSeries.getTimeSeriesNames(null), null);
         postProcessingTimeSeries = generatorProcessing.createPostProcessingTimeSeries();
         assertEquals(20, postProcessingTimeSeries.size());
 

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixLoadPostProcessingTimeSeriesTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixLoadPostProcessingTimeSeriesTest.java
@@ -8,6 +8,8 @@
 package com.powsybl.metrix.integration;
 
 import com.google.common.collect.Sets;
+import com.powsybl.contingency.BranchContingency;
+import com.powsybl.contingency.Contingency;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.serde.NetworkSerDe;
 import com.powsybl.metrix.integration.dataGenerator.MetrixOutputData;
@@ -28,6 +30,7 @@ import org.threeten.extra.Interval;
 
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -109,8 +112,9 @@ class MetrixLoadPostProcessingTimeSeriesTest {
         TimeSeriesMappingConfig mappingConfig = new TimeSeriesMappingConfig();
         MetrixDslDataLoader metrixDslDataLoader = new MetrixDslDataLoader(metrixConfigurationScript);
         MetrixDslData dslData = metrixDslDataLoader.load(network, parameters, store, new DataTableStore(), mappingConfig, null);
+        Contingency contingency = new Contingency("cty", List.of(new BranchContingency("FP.AND1  FVERGE1  1")));
 
-        MetrixLoadPostProcessingTimeSeries loadProcessing = new MetrixLoadPostProcessingTimeSeries(dslData, mappingConfig, metrixResultTimeSeries.getTimeSeriesNames(null), null);
+        MetrixLoadPostProcessingTimeSeries loadProcessing = new MetrixLoadPostProcessingTimeSeries(dslData, mappingConfig, List.of(contingency), metrixResultTimeSeries.getTimeSeriesNames(null), null);
         postProcessingTimeSeries = loadProcessing.createPostProcessingTimeSeries();
         assertEquals(8, postProcessingTimeSeries.size());
 

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixPostProcessingTimeSeriesTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixPostProcessingTimeSeriesTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.metrix.integration;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.powsybl.metrix.integration.MetrixPostProcessingTimeSeries.findIdsToProcess;
+
+/**
+ * @author Marianne Funfrock {@literal <marianne.funfrock at rte-france.com>}
+ */
+class MetrixPostProcessingTimeSeriesTest {
+
+    @Test
+    void findIdsToProcessSimpleTest() {
+        List<String> actual = findIdsToProcess(Set.of("id1", "id2"), Set.of("PREFIX_id1"), "PREFIX_");
+        Assertions.assertThat(actual).containsExactly("id1");
+    }
+
+    @Test
+    void findIdsToProcessSimpleWithSuffixTest() {
+        List<String> actual = findIdsToProcess(Set.of("id1", "id1_suffix"), Set.of("PREFIX_id1"), "PREFIX_");
+        Assertions.assertThat(actual).containsExactly("id1");
+    }
+
+    @Test
+    void findIdsToProcessComplexTest() {
+        List<String> actual = findIdsToProcess(Set.of("id1", "id2"), Set.of("PREFIX_id1_cty"), "PREFIX_", Set.of("cty"));
+        Assertions.assertThat(actual).containsExactly("id1");
+    }
+
+    @Test
+    void findIdsToProcessComplexWithSuffixTest() {
+        List<String> actual = findIdsToProcess(Set.of("id1", "id1_suffix"), Set.of("PREFIX_id1_cty"), "PREFIX_", Set.of("cty"));
+        Assertions.assertThat(actual).containsExactly("id1");
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Problem in finding equipment ids for which redispatching or load shedding metrix results exist when several identifiers start in the same way.
Example with ids 'CPNIE_ES_HY' and 'CPNIE_ES_HY_2B'
CPNIE_ES_HY_2B has redispatching results but CPNIE_ES_HY doesn't
The current behavior wrongly considers that 'CPNIE_ES_HY' has redispatching results too



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
