### PR TITLE
Curative post processing fix

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/postprocessing/AbstractMetrixEquipmentPostProcessing.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/postprocessing/AbstractMetrixEquipmentPostProcessing.java
@@ -17,14 +17,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.DOCTRINE_COSTS_ARE_NOT_PROPERLY_CONFIGURED;
+import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.buildEquipmentToCurativeTs;
+import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.buildEquipmentToPreventiveTs;
 import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.checkAllConfigured;
-import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.findIdsToProcess;
 import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.getContingencyIdFromTsName;
 
 /**
@@ -110,24 +110,14 @@ public abstract class AbstractMetrixEquipmentPostProcessing {
         String prefix = equipmentType.preventivePrefixContainer().getMetrixResultPrefix();
 
         // Filter equipment ids who have preventive time series results
-        List<String> idsToProcess = findIdsToProcess(getPreventiveIds(), allTimeSeriesNames, prefix);
-
-        for (String id : idsToProcess) {
-            equipmentToPreventiveTs.computeIfAbsent(id, k -> new HashSet<>()).add(prefix + id);
-        }
+        equipmentToPreventiveTs.putAll(buildEquipmentToPreventiveTs(getPreventiveIds(), allTimeSeriesNames, prefix));
     }
 
     private void initEquipmentToCurativeTs() {
         String prefix = equipmentType.curativePrefixContainer().getMetrixResultPrefix();
 
         // Filter equipment ids who have curative time series results
-        List<String> idsToProcess = findIdsToProcess(getCurativeIds(), allTimeSeriesNames, prefix, contingencyProbabilityById.keySet());
-
-        for (String id : idsToProcess) {
-            String elementIdPrefix = prefix + id;
-            List<String> elementTimeSeriesNames = allTimeSeriesNames.stream().filter(s -> s.startsWith(elementIdPrefix)).toList();
-            elementTimeSeriesNames.forEach(tsName -> equipmentToCurativeTs.computeIfAbsent(id, k -> new HashSet<>()).add(tsName));
-        }
+        equipmentToCurativeTs.putAll(buildEquipmentToCurativeTs(getCurativeIds(), allTimeSeriesNames, prefix, contingencyProbabilityById.keySet()));
     }
 
     private NodeCalc getContingencyProbability(String contingencyId) {

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/postprocessing/MetrixPostProcessingTimeSeries.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/postprocessing/MetrixPostProcessingTimeSeries.java
@@ -51,22 +51,52 @@ public final class MetrixPostProcessingTimeSeries {
     }
 
     /**
-     * Applies a filter on allIds : id is kept if allTimeSeriesNames contains a String starting with 'prefix' + 'id' + '_'
-     * and followed by one element of contingencyIds
+     * For each id having metrix results, find all time series names results of the form 'prefix + id'
+     * For preventive results only (redispatching and load shedding)
+     * @param allIds             list of equipment ids to filter
+     * @param allTimeSeriesNames all metrix results time series names
+     * @param prefix             prefix of metrix results time series names to keep
+     * @return map of equipment id to their corresponding time series names
+     */
+    public static Map<String, Set<String>> buildEquipmentToPreventiveTs(Set<String> allIds, Set<String> allTimeSeriesNames, String prefix) {
+        Map<String, Set<String>> result = new HashMap<>();
+        for (String id : allIds) {
+            String prefixAndId = prefix + id;
+            Set<String> tsNames = allTimeSeriesNames.stream()
+                .filter(tsName -> tsName.equals(prefixAndId))
+                .collect(Collectors.toSet());
+            if (!tsNames.isEmpty()) {
+                result.put(id, tsNames);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * For each id having metrix results, find all time series names results of the form 'prefix + id + contingency'
      * For curative results only (redispatching and load shedding)
      * @param allIds             list of equipment ids to filter
      * @param allTimeSeriesNames all metrix results time series names
      * @param prefix             prefix of metrix results time series names to keep
      * @param contingencyIds     list of contingency ids
+     * @return map of equipment id to their corresponding time series names
      */
-    public static List<String> findIdsToProcess(Set<String> allIds, Set<String> allTimeSeriesNames, String prefix, Set<String> contingencyIds) {
-        return allIds.stream().filter(id -> {
+    public static Map<String, Set<String>> buildEquipmentToCurativeTs(Set<String> allIds, Set<String> allTimeSeriesNames, String prefix, Set<String> contingencyIds) {
+        Map<String, Set<String>> result = new HashMap<>();
+        for (String id : allIds) {
             String prefixAndId = prefix + id + "_";
-            return allTimeSeriesNames.stream().filter(tsName -> tsName.startsWith(prefixAndId)).anyMatch(s -> {
-                String contingencyId = s.substring(prefixAndId.length());
-                return contingencyIds.contains(contingencyId);
-            });
-        }).toList();
+            Set<String> tsNames = allTimeSeriesNames.stream()
+                .filter(tsName -> tsName.startsWith(prefixAndId))
+                .filter(tsName -> {
+                    String contingencyId = tsName.substring(prefixAndId.length());
+                    return contingencyIds.contains(contingencyId);
+                })
+                .collect(Collectors.toSet());
+            if (!tsNames.isEmpty()) {
+                result.put(id, tsNames);
+            }
+        }
+        return result;
     }
 
     /**

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/postprocessing/MetrixPostProcessingTimeSeriesTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/postprocessing/MetrixPostProcessingTimeSeriesTest.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.buildEquipmentToCurativeTs;
+import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.buildEquipmentToPreventiveTs;
 import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.findIdsToProcess;
 import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.getContingencyIdFromTsName;
 import static com.powsybl.metrix.integration.postprocessing.MetrixPostProcessingTimeSeries.getProbabilityNodeCalc;
@@ -47,6 +49,18 @@ class MetrixPostProcessingTimeSeriesTest {
     void findIdsToProcessSimpleWithSuffixTest() {
         List<String> actual = findIdsToProcess(Set.of("id1", "id1_suffix"), Set.of("PREFIX_id1"), "PREFIX_");
         Assertions.assertThat(actual).containsExactly("id1");
+    }
+
+    @Test
+    void buildEquipmentToPreventiveTsTest() {
+        Map<String, Set<String>> actual = buildEquipmentToPreventiveTs(Set.of("id1", "id11"), Set.of("PREFIX_id1", "PREFIX_id11", "PREFIX_other"), "PREFIX_");
+        assertEquals(Map.of("id1", Set.of("PREFIX_id1"), "id11", Set.of("PREFIX_id11")), actual);
+    }
+
+    @Test
+    void buildEquipmentToCurativeTsTest() {
+        Map<String, Set<String>> actual = buildEquipmentToCurativeTs(Set.of("id1", "id11"), Set.of("PREFIX_id1_cty1", "PREFIX_id1_cty2", "PREFIX_id11_cty1", "PREFIX_other"), "PREFIX_", Set.of("cty1", "cty2"));
+        assertEquals(Map.of("id1", Set.of("PREFIX_id1_cty1", "PREFIX_id1_cty2"), "id11", Set.of("PREFIX_id11_cty1")), actual);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In cases where curative results are given for two identifiers, the first of which is identical to the beginning of the second, the curative postprocessing computation doesn't work and ends with an error message.

Example: for 'TOU.C6TR612' and 'TOU.C6TR6122' identifiers, the computation ends with the message 'Time series name 'LOAD_CUR_TOU.C6TR6122_SSVICY632' does not start with prefix 'LOAD_CUR_TOU.C6TR612_'


**What is the new behavior (if this is a feature change)?**
Postprocessing runs until the end


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
