### PR TITLE
Add timestamp to the logs if wanted

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/analysis/MetrixAnalysis.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/analysis/MetrixAnalysis.java
@@ -68,6 +68,7 @@ public class MetrixAnalysis {
     private System.Logger.Level maxLogLevel;
     private Writer inputLogWriter;
     private String schemaName;
+    private boolean withTimestamp;
 
     public void setUpdateTask(Consumer<Future<?>> updateTask) {
         this.updateTask = updateTask;
@@ -79,6 +80,10 @@ public class MetrixAnalysis {
 
     public void setMaxLogLevel(System.Logger.Level maxLogLevel) {
         this.maxLogLevel = maxLogLevel;
+    }
+
+    public void setWithTimestamp(boolean withTimestamp) {
+        this.withTimestamp = withTimestamp;
     }
 
     public void setInputLogWriter(Writer inputLogWriter) {
@@ -123,7 +128,16 @@ public class MetrixAnalysis {
 
         try (BufferedWriter scriptLogBufferedWriter = scriptLogWriter != null ? new BufferedWriter(scriptLogWriter) : null;
              BufferedWriter inputLogBufferedWriter = inputLogWriter != null ? new BufferedWriter(inputLogWriter) : null) {
-            ScriptLogConfig scriptLogConfig = new ScriptLogConfig(this.maxLogLevel, scriptLogBufferedWriter);
+            ScriptLogConfig scriptLogConfig = ScriptLogConfig.builder()
+                .maxLogLevel(this.maxLogLevel)
+                .writer(scriptLogBufferedWriter)
+                .withTimestamp(this.withTimestamp)
+                .build();
+            ScriptLogConfig inputLogConfig = ScriptLogConfig.builder()
+                .maxLogLevel(this.maxLogLevel)
+                .writer(inputLogBufferedWriter)
+                .withTimestamp(this.withTimestamp)
+                .build();
             TimeSeriesMappingConfig mappingConfig = loadMappingConfig(timeSeriesDslLoader, network, mappingParameters, scriptLogConfig, id);
             Map<String, NodeCalc> timeSeriesNodesAfterMapping = new HashMap<>(mappingConfig.getTimeSeriesNodes());
             MetrixDslData metrixDslData = null;
@@ -133,7 +147,7 @@ public class MetrixAnalysis {
                 timeSeriesNodesAfterMetrix = new HashMap<>(mappingConfig.getTimeSeriesNodes());
             }
             MetrixInputAnalysisResult inputs = new MetrixInputAnalysis(remedialActionsReader, contingenciesProvider,
-                network, metrixDslData, dataTableStore, inputLogBufferedWriter, scriptLogConfig).runAnalysis();
+                network, metrixDslData, dataTableStore, inputLogConfig, scriptLogConfig).runAnalysis();
             MetrixConfigResult metrixConfigResult = new MetrixConfigResult(timeSeriesNodesAfterMapping, timeSeriesNodesAfterMetrix);
             return new MetrixAnalysisResult(metrixDslData, mappingConfig, network, metrixParameters, mappingParameters,
                 metrixConfigResult, inputs.contingencies(), inputs.remedials());

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/analysis/MetrixInputAnalysis.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/analysis/MetrixInputAnalysis.java
@@ -18,6 +18,7 @@ import com.powsybl.metrix.integration.exceptions.ContingenciesScriptLoadingExcep
 import com.powsybl.metrix.integration.remedials.Remedial;
 import com.powsybl.metrix.integration.remedials.RemedialReader;
 import com.powsybl.metrix.mapping.config.ScriptLogConfig;
+import com.powsybl.metrix.mapping.log.LogUtils;
 
 import java.io.*;
 import java.util.*;
@@ -56,17 +57,16 @@ public class MetrixInputAnalysis {
     private final Network network;
     private final MetrixDslData metrixDslData;
     private final DataTableStore dataTableStore;
-    private final BufferedWriter writer;
+    private final ScriptLogConfig inputLogConfig;
     private final ScriptLogConfig scriptLogConfig;
 
     public MetrixInputAnalysis(Reader remedialActionsReader, ContingenciesProvider contingenciesProvider, Network network,
-                               MetrixDslData metrixDslData, DataTableStore dataTableStore, BufferedWriter writer) {
-        this(remedialActionsReader, contingenciesProvider, network, metrixDslData, dataTableStore, writer, new ScriptLogConfig());
+                               MetrixDslData metrixDslData, DataTableStore dataTableStore, ScriptLogConfig inputLogConfig) {
+        this(remedialActionsReader, contingenciesProvider, network, metrixDslData, dataTableStore, inputLogConfig, new ScriptLogConfig());
     }
 
     public MetrixInputAnalysis(Reader remedialActionsReader, ContingenciesProvider contingenciesProvider, Network network,
-                               MetrixDslData metrixDslData, DataTableStore dataTableStore,
-                               BufferedWriter writer,
+                               MetrixDslData metrixDslData, DataTableStore dataTableStore, ScriptLogConfig inputLogConfig,
                                ScriptLogConfig scriptLogConfig) {
         Objects.requireNonNull(contingenciesProvider);
         Objects.requireNonNull(network);
@@ -75,7 +75,7 @@ public class MetrixInputAnalysis {
         this.network = network;
         this.metrixDslData = metrixDslData;
         this.dataTableStore = dataTableStore;
-        this.writer = writer;
+        this.inputLogConfig = inputLogConfig;
         this.scriptLogConfig = scriptLogConfig;
     }
 
@@ -103,20 +103,8 @@ public class MetrixInputAnalysis {
         remedials.forEach(remedial -> checkRemedial(remedial, contingencyIds));
     }
 
-    private void writeLog(String type, String section, String message, BufferedWriter writer) {
-        if (writer == null) {
-            return;
-        }
-        try {
-            writer.write(type + SEPARATOR + section + SEPARATOR + message);
-            writer.newLine();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
     private void writeLog(String type, String section, String message) {
-        writeLog(type, section, message, writer);
+        LogUtils.logOut(inputLogConfig, type, section, message);
     }
 
     private void writeContingencyLog(String contingencyId, String elementId, String messageReason) {

--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/analysis/MetrixInputAnalysis.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/analysis/MetrixInputAnalysis.java
@@ -37,7 +37,6 @@ public class MetrixInputAnalysis {
         INFO
     }
 
-    private static final char SEPARATOR = ';';
     private static final String SECTION_SEPARATOR = " - ";
     private static final String COMMENT_SYMBOL = "/*";
     private static final String COMMENT_LINE_SYMBOL = "//";

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixExceptionTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/MetrixExceptionTest.java
@@ -96,7 +96,7 @@ class MetrixExceptionTest {
     @Test
     void loadContingenciesScriptExceptionTest() {
         ContingenciesProvider provider = new GroovyDslContingenciesProvider(wrongDslFile);
-        MetrixInputAnalysis metrixInputAnalysis = new MetrixInputAnalysis(new StringReader(""), provider, network, new MetrixDslData(), null, null, new ScriptLogConfig());
+        MetrixInputAnalysis metrixInputAnalysis = new MetrixInputAnalysis(new StringReader(""), provider, network, new MetrixDslData(), null, new ScriptLogConfig());
         assertThrows(ContingenciesScriptLoadingException.class, metrixInputAnalysis::runAnalysis);
     }
 

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/analysis/MetrixAnalysisTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/analysis/MetrixAnalysisTest.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -135,12 +136,35 @@ class MetrixAnalysisTest {
             MetrixAnalysis metrixAnalysis = metrixAnalysis(script, "");
             metrixAnalysis.setScriptLogWriter(out);
             metrixAnalysis.setMaxLogLevel(System.Logger.Level.WARNING);
+            metrixAnalysis.setWithTimestamp(false);
             metrixAnalysis.runAnalysis("");
             String output = outputStream.toString();
             assertEquals("""
                 WARNING;From scriptLogLevelTest;writeLog WARNING
                 ERROR;From scriptLogLevelTest;writeLog ERROR
                 """.replaceAll("\n", System.lineSeparator()), output);
+        }
+    }
+
+    @Test
+    void scriptWithTimestampTest() throws IOException {
+        String script = """
+            writeLog("ERROR", "From scriptLogLevelTest", "writeLog ERROR")""";
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (Writer out = new BufferedWriter(new OutputStreamWriter(outputStream))) {
+            MetrixAnalysis metrixAnalysis = metrixAnalysis(script, "");
+            metrixAnalysis.setScriptLogWriter(out);
+            metrixAnalysis.setMaxLogLevel(System.Logger.Level.WARNING);
+            metrixAnalysis.setWithTimestamp(true);
+            metrixAnalysis.runAnalysis("");
+            String output = outputStream.toString();
+            String[] outputSplitted = output.split(";");
+            assertEquals(4, outputSplitted.length);
+            assertNotNull(outputSplitted[0]);
+            assertEquals(20, outputSplitted[0].length()); // Format 2026-06-03T11:26:00Z
+            assertEquals("ERROR", outputSplitted[1]);
+            assertEquals("From scriptLogLevelTest", outputSplitted[2]);
+            assertEquals("writeLog ERROR" + System.lineSeparator(), outputSplitted[3]);
         }
     }
 

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/analysis/MetrixContingencyAnalysisTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/analysis/MetrixContingencyAnalysisTest.java
@@ -13,6 +13,7 @@ import com.powsybl.iidm.serde.NetworkSerDe;
 import com.powsybl.metrix.integration.MetrixDslData;
 import com.powsybl.metrix.integration.type.MetrixHvdcControlType;
 import com.powsybl.metrix.integration.type.MetrixPtcControlType;
+import com.powsybl.metrix.mapping.config.ScriptLogConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -66,7 +67,12 @@ class MetrixContingencyAnalysisTest {
     private void metrixDslDataContingencyAnalysisTest(MetrixDslData metrixDslData, String expected) throws IOException {
         StringWriter writer = new StringWriter();
         try (BufferedWriter bufferedWriter = new BufferedWriter(writer)) {
-            MetrixInputAnalysis metrixInputAnalysis = new MetrixInputAnalysis(new StringReader(""), new EmptyContingencyListProvider(), network, metrixDslData, null, bufferedWriter);
+            MetrixInputAnalysis metrixInputAnalysis = new MetrixInputAnalysis(new StringReader(""),
+                new EmptyContingencyListProvider(),
+                network,
+                metrixDslData,
+                null,
+                new ScriptLogConfig(bufferedWriter));
             metrixInputAnalysis.runAnalysis();
             bufferedWriter.flush();
             String actual = writer.toString();
@@ -81,7 +87,7 @@ class MetrixContingencyAnalysisTest {
 
         StringWriter writer = new StringWriter();
         try (BufferedWriter bufferedWriter = new BufferedWriter(writer)) {
-            MetrixInputAnalysis metrixInputAnalysis = new MetrixInputAnalysis(new StringReader(""), provider, network, new MetrixDslData(), null, bufferedWriter);
+            MetrixInputAnalysis metrixInputAnalysis = new MetrixInputAnalysis(new StringReader(""), provider, network, new MetrixDslData(), null, new ScriptLogConfig(bufferedWriter));
             metrixInputAnalysis.runAnalysis();
             bufferedWriter.flush();
             String actual = writer.toString();
@@ -169,7 +175,7 @@ class MetrixContingencyAnalysisTest {
                     String.join(System.lineSeparator(),
                             "NB;1;",
                             "ctyId;1;FP.AND1  FVERGE1  1;")
-            ), new EmptyContingencyListProvider(), network, new MetrixDslData(), null, bufferedWriter);
+            ), new EmptyContingencyListProvider(), network, new MetrixDslData(), null, new ScriptLogConfig(bufferedWriter));
             metrixInputAnalysis.runAnalysis();
             bufferedWriter.flush();
             String actual = writer.toString();

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/analysis/MetrixRemedialAnalysisTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/analysis/MetrixRemedialAnalysisTest.java
@@ -15,6 +15,7 @@ import com.powsybl.contingency.EmptyContingencyListProvider;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.serde.NetworkSerDe;
 import com.powsybl.metrix.integration.MetrixDslData;
+import com.powsybl.metrix.mapping.config.ScriptLogConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,7 +89,7 @@ class MetrixRemedialAnalysisTest {
                 network,
                 metrixDslData,
                 null,
-                bufferedWriter);
+                new ScriptLogConfig(bufferedWriter));
             metrixInputAnalysis.runAnalysis();
             bufferedWriter.flush();
             String actual = writer.toString();

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/log/LogUtils.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/log/LogUtils.groovy
@@ -9,13 +9,14 @@ package com.powsybl.metrix.mapping.log
 
 import com.powsybl.metrix.mapping.config.ScriptLogConfig
 
+import java.time.Instant
+
 import static java.lang.System.Logger.Level.valueOf
 
 /**
  * @author Matthieu SAUR {@literal <matthieu.saur at rte-france.com>}
  */
 class LogUtils {
-    private static final char SEPARATOR = ';'
 
     static void bindLog(Binding binding, ScriptLogConfig scriptLogConfig) {
         binding.writeLog = { String type, String section, String message ->
@@ -29,9 +30,14 @@ class LogUtils {
 
     static void logOut(ScriptLogConfig scriptLogConfig, String logLevel, String section, String message) {
         if (scriptLogConfig != null && scriptLogConfig.getWriter() != null && canLog(logLevel, scriptLogConfig.getMaxLogLevel())) {
-            scriptLogConfig.getWriter().write(logLevel + SEPARATOR + section + SEPARATOR + message)
-            scriptLogConfig.getWriter().write(System.lineSeparator())
+            String timeStampFormatted = scriptLogConfig.getDateTimeFormatter().format(getInstantNow(scriptLogConfig))
+            String line = buildLine(logLevel, section, message, scriptLogConfig.isWithTimeStamp(), timeStampFormatted)
+            scriptLogConfig.getWriter().write(line)
         }
+    }
+
+    private static Instant getInstantNow(ScriptLogConfig scriptLogConfig) {
+        Instant.now(scriptLogConfig.getClock())
     }
 
     static boolean canLog(String type, System.Logger.Level maxLevelToLog) {
@@ -51,4 +57,16 @@ class LogUtils {
             return Integer.MAX_VALUE
         }
     }
+
+    private static String buildLine(String logLevel, String section, String message, boolean isWithTimestamp, String timeStampFormatted) {
+        List<String> line = new ArrayList<>()
+        if (isWithTimestamp) {
+            line.add(timeStampFormatted)
+        }
+        line.add(logLevel)
+        line.add(section)
+        line.add(message)
+        return String.join(";", line) + System.lineSeparator()
+    }
+
 }

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/config/ScriptLogConfig.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/config/ScriptLogConfig.java
@@ -10,6 +10,9 @@ package com.powsybl.metrix.mapping.config;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Writer;
+import java.time.Clock;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 import static java.lang.System.Logger.Level.INFO;
 
@@ -18,10 +21,15 @@ import static java.lang.System.Logger.Level.INFO;
  */
 public class ScriptLogConfig {
     public static final System.Logger.Level MAX_LOG_LEVEL_DEFAULT = INFO;
+    public static final DateTimeFormatter DATE_TIME_FORMATTER_DEFAULT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+    public static final boolean WITH_TIMESTAMP_DEFAULT = false;
 
     private Writer writer;
     private System.Logger.Level maxLogLevel;
     private String section;
+    private boolean withTimestamp;
+    private DateTimeFormatter dateTimeFormatter;
+    private final Clock clock;
 
     public ScriptLogConfig() {
         this(MAX_LOG_LEVEL_DEFAULT, null, StringUtils.EMPTY);
@@ -36,9 +44,29 @@ public class ScriptLogConfig {
     }
 
     public ScriptLogConfig(System.Logger.Level maxLogLevel, Writer writer, String section) {
+        this(maxLogLevel, writer, section, WITH_TIMESTAMP_DEFAULT);
+    }
+
+    public ScriptLogConfig(System.Logger.Level maxLogLevel, Writer writer, String section, boolean withTimestamp) {
+        this(maxLogLevel, writer, section, withTimestamp, DATE_TIME_FORMATTER_DEFAULT);
+    }
+
+    public ScriptLogConfig(System.Logger.Level maxLogLevel, Writer writer, String section, boolean withTimestamp, DateTimeFormatter dateTimeFormatter) {
         this.maxLogLevel = maxLogLevel;
         this.writer = writer;
         this.section = section;
+        this.withTimestamp = withTimestamp;
+        this.dateTimeFormatter = dateTimeFormatter;
+        this.clock = Clock.systemUTC();
+    }
+
+    private ScriptLogConfig(Builder builder) {
+        this.writer = builder.writer;
+        this.maxLogLevel = builder.maxLogLevel;
+        this.section = builder.section;
+        this.withTimestamp = builder.withTimestamp;
+        this.dateTimeFormatter = builder.dateTimeFormatter;
+        this.clock = builder.clock;
     }
 
     public ScriptLogConfig withSection(String section) {
@@ -56,6 +84,16 @@ public class ScriptLogConfig {
         return this;
     }
 
+    public ScriptLogConfig withTimeStamp(boolean withTimestamp) {
+        this.withTimestamp = withTimestamp;
+        return this;
+    }
+
+    public ScriptLogConfig withDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+        this.dateTimeFormatter = dateTimeFormatter;
+        return this;
+    }
+
     public System.Logger.Level getMaxLogLevel() {
         return maxLogLevel != null ? maxLogLevel : MAX_LOG_LEVEL_DEFAULT;
     }
@@ -66,5 +104,68 @@ public class ScriptLogConfig {
 
     public String getSection() {
         return section;
+    }
+
+    public boolean isWithTimeStamp() {
+        return this.withTimestamp;
+    }
+
+    public DateTimeFormatter getDateTimeFormatter() {
+        return dateTimeFormatter;
+    }
+
+    public Clock getClock() {
+        return this.clock;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private Writer writer = null;
+        private System.Logger.Level maxLogLevel = MAX_LOG_LEVEL_DEFAULT;
+        private String section = null;
+        private boolean withTimestamp = WITH_TIMESTAMP_DEFAULT;
+        private DateTimeFormatter dateTimeFormatter = DATE_TIME_FORMATTER_DEFAULT;
+        private Clock clock = Clock.systemUTC();
+
+        private Builder() {
+        }
+
+        public Builder writer(Writer writer) {
+            this.writer = writer;
+            return this;
+        }
+
+        public Builder maxLogLevel(System.Logger.Level maxLogLevel) {
+            this.maxLogLevel = maxLogLevel;
+            return this;
+        }
+
+        public Builder section(String section) {
+            this.section = section;
+            return this;
+        }
+
+        public Builder withTimestamp(boolean withTimestamp) {
+            this.withTimestamp = withTimestamp;
+            return this;
+        }
+
+        public Builder dateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+            this.dateTimeFormatter = dateTimeFormatter;
+            return this;
+        }
+
+        public Builder clock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
+        public ScriptLogConfig build() {
+            return new ScriptLogConfig(this);
+        }
     }
 }

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesDslLoaderTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/TimeSeriesDslLoaderTest.java
@@ -54,7 +54,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -403,6 +406,31 @@ class TimeSeriesDslLoaderTest {
 
         String output = outputStream.toString();
         String expectedMessage = "LOG_TYPE;LOG_SECTION;LOG_MESSAGE" + System.lineSeparator();
+        assertEquals(expectedMessage, output);
+    }
+
+    @Test
+    void writeLogTestWithTimestamp() throws IOException {
+        Clock fixedClock = Clock.fixed(Instant.parse("2026-06-03T07:15:38Z"), ZoneOffset.UTC);
+        ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache();
+        String script = """
+            writeLog("LOG_TYPE", "LOG_SECTION", "LOG_MESSAGE")
+            """;
+
+        TimeSeriesDslLoader dsl = new TimeSeriesDslLoader(script);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (Writer out = new BufferedWriter(new OutputStreamWriter(outputStream))) {
+            ScriptLogConfig scriptLogConfig = ScriptLogConfig.builder()
+                .writer(out)
+                .withTimestamp(true)
+                .clock(fixedClock)
+                .build();
+            dsl.load(network, parameters, store, new DataTableStore(), scriptLogConfig, null);
+        }
+
+        String output = outputStream.toString();
+        String expectedMessage = "2026-06-03T07:15:38Z;LOG_TYPE;LOG_SECTION;LOG_MESSAGE" + System.lineSeparator();
         assertEquals(expectedMessage, output);
     }
 

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/config/ScriptLogConfigTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/config/ScriptLogConfigTest.java
@@ -43,12 +43,47 @@ class ScriptLogConfigTest {
         // THEN
         assertNotNull(scriptLogConfig);
         assertNull(scriptLogConfig.getWriter());
-        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
         assertEquals(MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
+        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
+        assertFalse(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
     }
 
     @Test
-    void testConstructorFull() {
+    void testConstructorWriter() {
+        // GIVEN
+        StringWriter sw = new StringWriter();
+        // WHEN
+        ScriptLogConfig scriptLogConfig = new ScriptLogConfig(sw);
+        // THEN
+        assertNotNull(scriptLogConfig);
+        assertEquals(sw, scriptLogConfig.getWriter());
+        assertEquals(MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
+        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
+        assertFalse(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
+    }
+
+    @Test
+    void testConstructorMaxLogLevelWriter() {
+        // GIVEN
+        StringWriter sw = new StringWriter();
+        // WHEN
+        ScriptLogConfig scriptLogConfig = new ScriptLogConfig(ERROR, sw);
+        // THEN
+        assertNotNull(scriptLogConfig);
+        assertEquals(sw, scriptLogConfig.getWriter());
+        assertEquals(ERROR, scriptLogConfig.getMaxLogLevel());
+        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
+        assertFalse(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
+    }
+
+    @Test
+    void testConstructorMaxLogLevelWriterSection() {
         // GIVEN
         StringWriter sw = new StringWriter();
         // WHEN
@@ -56,63 +91,20 @@ class ScriptLogConfigTest {
         // THEN
         assertNotNull(scriptLogConfig);
         assertEquals(sw, scriptLogConfig.getWriter());
-        assertEquals(SECTION, scriptLogConfig.getSection());
         assertEquals(ERROR, scriptLogConfig.getMaxLogLevel());
+        assertEquals(SECTION, scriptLogConfig.getSection());
+        assertFalse(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
     }
 
     @Test
-    void testConstructors() {
+    void testConstructorMaxLogLevelWriterSectionWithTimestamp() {
         // GIVEN
         StringWriter sw = new StringWriter();
         boolean withTimestamp = true;
-        ScriptLogConfig scriptLogConfig;
-
         // WHEN
-        scriptLogConfig = new ScriptLogConfig();
-        // THEN
-        assertNotNull(scriptLogConfig);
-        assertNull(scriptLogConfig.getWriter());
-        assertEquals(MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
-        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
-        assertFalse(scriptLogConfig.isWithTimeStamp());
-        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
-        assertNotNull(scriptLogConfig.getClock());
-
-        // WHEN
-        scriptLogConfig = new ScriptLogConfig(sw);
-        // THEN
-        assertNotNull(scriptLogConfig);
-        assertEquals(sw, scriptLogConfig.getWriter());
-        assertEquals(MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
-        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
-        assertFalse(scriptLogConfig.isWithTimeStamp());
-        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
-        assertNotNull(scriptLogConfig.getClock());
-
-        // WHEN
-        scriptLogConfig = new ScriptLogConfig(ERROR, sw);
-        // THEN
-        assertNotNull(scriptLogConfig);
-        assertEquals(sw, scriptLogConfig.getWriter());
-        assertEquals(ERROR, scriptLogConfig.getMaxLogLevel());
-        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
-        assertFalse(scriptLogConfig.isWithTimeStamp());
-        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
-        assertNotNull(scriptLogConfig.getClock());
-
-        // WHEN
-        scriptLogConfig = new ScriptLogConfig(ERROR, sw, SECTION);
-        // THEN
-        assertNotNull(scriptLogConfig);
-        assertEquals(sw, scriptLogConfig.getWriter());
-        assertEquals(ERROR, scriptLogConfig.getMaxLogLevel());
-        assertEquals(SECTION, scriptLogConfig.getSection());
-        assertFalse(scriptLogConfig.isWithTimeStamp());
-        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
-        assertNotNull(scriptLogConfig.getClock());
-
-        // WHEN
-        scriptLogConfig = new ScriptLogConfig(ERROR, sw, SECTION, withTimestamp);
+        ScriptLogConfig scriptLogConfig = new ScriptLogConfig(ERROR, sw, SECTION, withTimestamp);
         // THEN
         assertNotNull(scriptLogConfig);
         assertEquals(sw, scriptLogConfig.getWriter());
@@ -121,9 +113,15 @@ class ScriptLogConfigTest {
         assertTrue(scriptLogConfig.isWithTimeStamp());
         assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
         assertNotNull(scriptLogConfig.getClock());
+    }
 
+    @Test
+    void testConstructorMaxLogLevelWriterSectionWithTimestampDateTimeFormatter() {
+        // GIVEN
+        StringWriter sw = new StringWriter();
+        boolean withTimestamp = true;
         // WHEN
-        scriptLogConfig = new ScriptLogConfig(ERROR, sw, SECTION, withTimestamp, DATE_TIME_FORMATTER);
+        ScriptLogConfig scriptLogConfig = new ScriptLogConfig(ERROR, sw, SECTION, withTimestamp, DATE_TIME_FORMATTER);
         // THEN
         assertNotNull(scriptLogConfig);
         assertEquals(sw, scriptLogConfig.getWriter());

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/config/ScriptLogConfigTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/config/ScriptLogConfigTest.java
@@ -11,13 +11,21 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
+import static com.powsybl.metrix.mapping.config.ScriptLogConfig.DATE_TIME_FORMATTER_DEFAULT;
+import static com.powsybl.metrix.mapping.config.ScriptLogConfig.MAX_LOG_LEVEL_DEFAULT;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Matthieu SAUR {@literal <matthieu.saur at rte-france.com>}
@@ -25,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class ScriptLogConfigTest {
 
     private static final String SECTION = "SECTION";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm'Z'").withZone(ZoneOffset.UTC);
 
     @Test
     void testConstructorEmpty() {
@@ -35,7 +44,7 @@ class ScriptLogConfigTest {
         assertNotNull(scriptLogConfig);
         assertNull(scriptLogConfig.getWriter());
         assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
-        assertEquals(ScriptLogConfig.MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
+        assertEquals(MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
     }
 
     @Test
@@ -55,19 +64,74 @@ class ScriptLogConfigTest {
     void testConstructors() {
         // GIVEN
         StringWriter sw = new StringWriter();
-        // WHEN
-        ScriptLogConfig scriptLogConfig1 = new ScriptLogConfig(sw);
-        ScriptLogConfig scriptLogConfig2 = new ScriptLogConfig(ERROR, sw);
-        // THEN
-        assertNotNull(scriptLogConfig1);
-        assertEquals(sw, scriptLogConfig1.getWriter());
-        assertEquals(StringUtils.EMPTY, scriptLogConfig1.getSection());
-        assertEquals(ScriptLogConfig.MAX_LOG_LEVEL_DEFAULT, scriptLogConfig1.getMaxLogLevel());
+        boolean withTimestamp = true;
+        ScriptLogConfig scriptLogConfig;
 
-        assertNotNull(scriptLogConfig2);
-        assertEquals(sw, scriptLogConfig2.getWriter());
-        assertEquals(StringUtils.EMPTY, scriptLogConfig2.getSection());
-        assertEquals(ERROR, scriptLogConfig2.getMaxLogLevel());
+        // WHEN
+        scriptLogConfig = new ScriptLogConfig();
+        // THEN
+        assertNotNull(scriptLogConfig);
+        assertNull(scriptLogConfig.getWriter());
+        assertEquals(MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
+        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
+        assertFalse(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
+
+        // WHEN
+        scriptLogConfig = new ScriptLogConfig(sw);
+        // THEN
+        assertNotNull(scriptLogConfig);
+        assertEquals(sw, scriptLogConfig.getWriter());
+        assertEquals(MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
+        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
+        assertFalse(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
+
+        // WHEN
+        scriptLogConfig = new ScriptLogConfig(ERROR, sw);
+        // THEN
+        assertNotNull(scriptLogConfig);
+        assertEquals(sw, scriptLogConfig.getWriter());
+        assertEquals(ERROR, scriptLogConfig.getMaxLogLevel());
+        assertEquals(StringUtils.EMPTY, scriptLogConfig.getSection());
+        assertFalse(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
+
+        // WHEN
+        scriptLogConfig = new ScriptLogConfig(ERROR, sw, SECTION);
+        // THEN
+        assertNotNull(scriptLogConfig);
+        assertEquals(sw, scriptLogConfig.getWriter());
+        assertEquals(ERROR, scriptLogConfig.getMaxLogLevel());
+        assertEquals(SECTION, scriptLogConfig.getSection());
+        assertFalse(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
+
+        // WHEN
+        scriptLogConfig = new ScriptLogConfig(ERROR, sw, SECTION, withTimestamp);
+        // THEN
+        assertNotNull(scriptLogConfig);
+        assertEquals(sw, scriptLogConfig.getWriter());
+        assertEquals(ERROR, scriptLogConfig.getMaxLogLevel());
+        assertEquals(SECTION, scriptLogConfig.getSection());
+        assertTrue(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER_DEFAULT, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
+
+        // WHEN
+        scriptLogConfig = new ScriptLogConfig(ERROR, sw, SECTION, withTimestamp, DATE_TIME_FORMATTER);
+        // THEN
+        assertNotNull(scriptLogConfig);
+        assertEquals(sw, scriptLogConfig.getWriter());
+        assertEquals(ERROR, scriptLogConfig.getMaxLogLevel());
+        assertEquals(SECTION, scriptLogConfig.getSection());
+        assertTrue(scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER, scriptLogConfig.getDateTimeFormatter());
+        assertNotNull(scriptLogConfig.getClock());
     }
 
     @Test
@@ -89,7 +153,7 @@ class ScriptLogConfigTest {
         ScriptLogConfig scriptLogConfigWith = scriptLogConfig.withMaxLogLevel(null);
         // THEN
         assertEquals(scriptLogConfig, scriptLogConfigWith);
-        assertEquals(ScriptLogConfig.MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
+        assertEquals(MAX_LOG_LEVEL_DEFAULT, scriptLogConfig.getMaxLogLevel());
     }
 
     @Test
@@ -114,5 +178,52 @@ class ScriptLogConfigTest {
         // THEN
         assertEquals(scriptLogConfig, scriptLogConfigWith);
         assertEquals(SECTION, scriptLogConfig.getSection());
+    }
+
+    @Test
+    void testWithTimeStamp() {
+        // GIVEN
+        ScriptLogConfig scriptLogConfig = new ScriptLogConfig();
+        // WHEN
+        ScriptLogConfig scriptLogConfigWith = scriptLogConfig.withTimeStamp(true);
+        // THEN
+        assertEquals(scriptLogConfig, scriptLogConfigWith);
+        assertTrue(scriptLogConfig.isWithTimeStamp());
+    }
+
+    @Test
+    void testWithDateTimeFormatter() {
+        // GIVEN
+        ScriptLogConfig scriptLogConfig = new ScriptLogConfig();
+        // WHEN
+        ScriptLogConfig scriptLogConfigWith = scriptLogConfig.withDateTimeFormatter(DATE_TIME_FORMATTER);
+        // THEN
+        assertEquals(scriptLogConfig, scriptLogConfigWith);
+        assertEquals(DATE_TIME_FORMATTER, scriptLogConfig.getDateTimeFormatter());
+    }
+
+    @Test
+    void testBuilder() {
+        // GIVEN
+        StringWriter sw = new StringWriter();
+        boolean withTimestamp = true;
+        Clock fixedClock = Clock.fixed(Instant.parse("2026-06-03T07:15:38Z"), ZoneOffset.UTC);
+        // WHEN
+        ScriptLogConfig scriptLogConfig = ScriptLogConfig.builder()
+            .writer(sw)
+            .maxLogLevel(ERROR)
+            .section(SECTION)
+            .withTimestamp(withTimestamp)
+            .dateTimeFormatter(DATE_TIME_FORMATTER)
+            .clock(fixedClock)
+            .build();
+        // THEN
+        assertNotNull(scriptLogConfig);
+        assertEquals(sw, scriptLogConfig.getWriter());
+        assertEquals(ERROR, scriptLogConfig.getMaxLogLevel());
+        assertEquals(SECTION, scriptLogConfig.getSection());
+        assertEquals(withTimestamp, scriptLogConfig.isWithTimeStamp());
+        assertEquals(DATE_TIME_FORMATTER, scriptLogConfig.getDateTimeFormatter());
+        assertEquals(fixedClock, scriptLogConfig.getClock());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
WriteLog write the timestamp if the withTimestamp attribute is `true`


**What is the current behavior?**
<!-- You can also link to an open issue here -->
WriteLog write only the LogLevel, the Section, and the Message


**What is the new behavior (if this is a feature change)?**
WriteLog write the timestamp if the withTimestamp attribute is `true`


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Use `ScriptLogConfig` instead of the writer with the `MetrixInputAnalysis` constructor
`new ScriptLogConfig(writer)`

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
