### PR TITLE
Fix potential ValidationException error in network extraction

### DIFF
--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/NetworkPointWriter.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/NetworkPointWriter.java
@@ -328,6 +328,8 @@ public class NetworkPointWriter extends DefaultTimeSeriesMapperObserver {
         for (Map.Entry<String, GeneratorInitialValues> e : generatorToInitialValues.entrySet()) {
             Generator g = network.getGenerator(e.getKey());
             GeneratorInitialValues initialValues = e.getValue();
+            // Set maxP to maxValue to pass ValidationUtil.checkActivePowerLimits
+            g.setMaxP(Double.MAX_VALUE);
             g.setMinP(initialValues.minP);
             g.setMaxP(initialValues.maxP);
         }

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/NetworkPointWriterTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/NetworkPointWriterTest.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.TreeSet;
 
 import static com.powsybl.commons.test.ComparisonUtils.assertXmlEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -152,6 +153,35 @@ class NetworkPointWriterTest {
             );
 
             assertMapping(script, store, expectedDirectoryName);
+        }
+    }
+
+    @Test
+    void networkPointGeneratorRestoreInitialStateTest() throws Exception {
+        try (InputStream scriptStream = Objects.requireNonNull(getClass().getResourceAsStream("/network_point_writer_mapping_script.groovy"))) {
+            // Mapping script
+            String script = new String(scriptStream.readAllBytes(), StandardCharsets.UTF_8);
+
+            ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache(
+                TimeSeries.createDouble("constant_ts1", index, -5d, -5d),
+                TimeSeries.createDouble("constant_ts2", index, 3000d, 3000d),
+                TimeSeries.createDouble("variable_ts1", index, -10d, -11d),
+                TimeSeries.createDouble("switch_ts", index, 0d, 1d),
+                TimeSeries.createDouble("ts1", index, 10d, 11d),
+                TimeSeries.createDouble("ts2", index, -10d, -11d),
+                TimeSeries.createDouble("power_factor_ts", index, 0d, 1d),
+                TimeSeries.createDouble("regulation_mode_ts", index, 0d, 1d)
+            );
+
+            // Create Mapper
+            TimeSeriesMapper mapper = prepareMapper(script, store);
+
+            // Launch mapper
+            // FSSV.O11_G generator in base case minP=0 maxP=500
+            // mapping of maxP with constant_ts1 time series -> maxP=-5
+            // mapping of minP with variable_ts1 time series -> minP=-10
+            // restoreInitialState to minP=0 should pass ValidationUtil.checkActivePowerLimits
+            assertDoesNotThrow(() -> mapper.mapToNetwork(store, networkPointWriterList));
         }
     }
 

--- a/metrix-mapping/src/test/resources/network_point_writer_mapping_script.groovy
+++ b/metrix-mapping/src/test/resources/network_point_writer_mapping_script.groovy
@@ -32,6 +32,11 @@ mapToBatteries {
     variable minP
 }
 mapToGenerators {
+    timeSeriesName 'variable_ts1'
+    filter {generator.id == 'FSSV.O11_G'}
+    variable minP
+}
+mapToGenerators {
     timeSeriesName 'constant_ts1'
     filter {generator.id == 'FSSV.O11_G'}
     variable maxP
@@ -39,11 +44,6 @@ mapToGenerators {
 mapToGenerators {
     timeSeriesName 'constant_ts2'
     filter {generator.id == 'FSSV.O12_G'}
-}
-mapToGenerators {
-    timeSeriesName 'variable_ts1'
-    filter {generator.id == 'FSSV.O11_G'}
-    variable minP
 }
 mapToGenerators {
     timeSeriesName 'ts1'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Network point extraction ends with invalid active limits error message. This happens when generator minP and maxP mapped values are manually cleared (minP and maxP are not processed by the network variant manager) to retrieve the base case network. The network can go through inconsistent transient states.

**What is the new behavior (if this is a feature change)?**
Network point extraction ends succesfully


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
