### PR TITLE
Add CMAKE_POLICY_VERSION_MINIMUM to manage update of windows-latest to windows-2025

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -162,7 +162,7 @@ jobs:
 
   cpp_windows:
     name: Build C++ Windows
-    runs-on: windows-2025
+    runs-on: windows-2022
     defaults:
       run:
         shell: cmd

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -162,7 +162,7 @@ jobs:
 
   cpp_windows:
     name: Build C++ Windows
-    runs-on: windows-latest
+    runs-on: windows-2025
     defaults:
       run:
         shell: cmd

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -162,13 +162,14 @@ jobs:
 
   cpp_windows:
     name: Build C++ Windows
-    runs-on: windows-2022
+    runs-on: windows-latest
     defaults:
       run:
         shell: cmd
     env:
       BOOST_ROOT: C:\thirdparties\boost-1.72.0
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     steps:
       - name: Install Boost
         run: |

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -125,7 +125,7 @@ jobs:
 
   cpp_windows:
     name: Build C++ Windows
-    runs-on: windows-latest
+    runs-on: windows-2025
     defaults:
       run:
         shell: cmd

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -125,13 +125,14 @@ jobs:
 
   cpp_windows:
     name: Build C++ Windows
-    runs-on: windows-2025
+    runs-on: windows-latest
     defaults:
       run:
         shell: cmd
     env:
       BOOST_ROOT: C:\thirdparties\boost-1.72.0
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     steps:
       - name: Install Boost
         run: |

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -144,6 +144,7 @@ jobs:
     env:
       BOOST_ROOT: C:\thirdparties\boost-1.72.0
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     steps:
       - name: Install Boost
         run: |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
The update of windows-latest to windows-2025 removed some compatibility on CMake, which raised this issue:

```
Performing configure step for 'suitesparse'
loading initial cache file .../suitesparse-cache-Release.cmake
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
  ...
  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
-- Configuring incomplete, errors occurred!
```

**What is the new behavior (if this is a feature change)?**
We add `CMAKE_POLICY_VERSION_MINIMUM` on windows builds to allow compatibility.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
