### PR TITLE
Give access to time series names in mapping script

### DIFF
--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/ScriptTimeSeriesNames.java
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/ScriptTimeSeriesNames.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.metrix.mapping;
+
+import java.util.Set;
+
+/**
+ * @author Marianne Funfrock {@literal <marianne.funfrock at rte-france.com>}
+ */
+public class ScriptTimeSeriesNames {
+
+    private final Set<String> inputNames;
+    private final Set<String> calculatedNames;
+
+    public Set<String> getInputNames() {
+        return inputNames;
+    }
+
+    public Set<String> getCalculatedNames() {
+        return calculatedNames;
+    }
+
+    public ScriptTimeSeriesNames(Set<String> inputNames, Set<String> calculatedNames) {
+        this.calculatedNames = calculatedNames;
+        this.inputNames = inputNames;
+    }
+}

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/ScriptTimeSeriesNamesGroovyScriptExtension.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/ScriptTimeSeriesNamesGroovyScriptExtension.groovy
@@ -27,16 +27,13 @@ class ScriptTimeSeriesNamesGroovyScriptExtension implements GroovyScriptExtensio
         if (contextObjects.keySet().contains(ScriptTimeSeriesNames.class)) {
             ScriptTimeSeriesNames scriptTimeSeriesNames = contextObjects.get(ScriptTimeSeriesNames.class) as ScriptTimeSeriesNames
             binding.inputTsNames = {
-                return new HashSet<>(scriptTimeSeriesNames.inputNames)
+                return scriptTimeSeriesNames.inputNames.asImmutable()
             }
             binding.calculatedTsNames = {
-                return new HashSet<>(scriptTimeSeriesNames.calculatedNames)
+                return scriptTimeSeriesNames.calculatedNames.asImmutable()
             }
             binding.tsNames = {
-                Set<String> tsNames = new HashSet<>()
-                tsNames.addAll(scriptTimeSeriesNames.inputNames)
-                tsNames.addAll(scriptTimeSeriesNames.calculatedNames)
-                return tsNames
+                return (scriptTimeSeriesNames.inputNames + scriptTimeSeriesNames.calculatedNames).asImmutable()
             }
             binding.inputTsExists = { String tsName ->
                 return exists(tsName, scriptTimeSeriesNames.inputNames)

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/ScriptTimeSeriesNamesGroovyScriptExtension.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/ScriptTimeSeriesNamesGroovyScriptExtension.groovy
@@ -1,0 +1,49 @@
+package com.powsybl.metrix.mapping
+
+import com.google.auto.service.AutoService
+import com.powsybl.scripting.groovy.GroovyScriptExtension
+
+/**
+ * @author Marianne Funfrock {@literal <marianne.funfrock at rte-france.com>}
+ */
+@AutoService(GroovyScriptExtension.class)
+class ScriptTimeSeriesNamesGroovyScriptExtension implements GroovyScriptExtension {
+
+    ScriptTimeSeriesNamesGroovyScriptExtension() {}
+
+    private static boolean exists(String tsName, Set<String> tsNames) {
+        return tsNames.contains(tsName)
+    }
+
+    @Override
+    void load(Binding binding, Map<Class<?>, Object> contextObjects) {
+        if (contextObjects.keySet().contains(ScriptTimeSeriesNames.class)) {
+            ScriptTimeSeriesNames scriptTimeSeriesNames = contextObjects.get(ScriptTimeSeriesNames.class) as ScriptTimeSeriesNames
+            binding.inputTsNames = {
+                return new HashSet<>(scriptTimeSeriesNames.inputNames)
+            }
+            binding.calculatedTsNames = {
+                return new HashSet<>(scriptTimeSeriesNames.calculatedNames)
+            }
+            binding.tsNames = {
+                Set<String> tsNames = new HashSet<>()
+                tsNames.addAll(scriptTimeSeriesNames.inputNames)
+                tsNames.addAll(scriptTimeSeriesNames.calculatedNames)
+                return tsNames
+            }
+            binding.inputTsExists = { String tsName ->
+                return exists(tsName, scriptTimeSeriesNames.inputNames)
+            }
+            binding.calculatedTsExists = { String tsName ->
+                return exists(tsName, scriptTimeSeriesNames.calculatedNames)
+            }
+            binding.tsExists = { String tsName ->
+                return exists(tsName, scriptTimeSeriesNames.calculatedNames) || exists(tsName, scriptTimeSeriesNames.inputNames)
+            }
+        }
+    }
+
+    @Override
+    void unload() {
+    }
+}

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/ScriptTimeSeriesNamesGroovyScriptExtension.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/ScriptTimeSeriesNamesGroovyScriptExtension.groovy
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
 package com.powsybl.metrix.mapping
 
 import com.google.auto.service.AutoService

--- a/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
+++ b/metrix-mapping/src/main/groovy/com/powsybl/metrix/mapping/TimeSeriesDslLoader.groovy
@@ -114,6 +114,7 @@ class TimeSeriesDslLoader {
         Map<Class<?>, Object> contextObjects = new HashMap<>()
         contextObjects.put(DataTableStore.class, dataTableStore)
         contextObjects.put(ScriptLogConfig.class, logDslLoader.getScriptLogConfig())
+        contextObjects.put(ScriptTimeSeriesNames.class, new ScriptTimeSeriesNames(loader.getInputTimeSeriesNames(), loader.getCalculatedTsNames()))
 
         // External Bindings
         CalculatedTimeSeriesGroovyDslLoader.bind(binding, store, config.getTimeSeriesNodes())

--- a/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/config/TimeSeriesMappingConfigLoader.java
+++ b/metrix-mapping/src/main/java/com/powsybl/metrix/mapping/config/TimeSeriesMappingConfigLoader.java
@@ -44,6 +44,14 @@ public class TimeSeriesMappingConfigLoader implements DefaultGenericMetadata {
     private final TimeSeriesMappingConfig config;
     private final Set<String> existingTimeSeriesNames;
 
+    public Set<String> getInputTimeSeriesNames() {
+        return existingTimeSeriesNames;
+    }
+
+    public Set<String> getCalculatedTsNames() {
+        return config.getTimeSeriesNodesKeys();
+    }
+
     public TimeSeriesMappingConfigLoader(TimeSeriesMappingConfig config, Set<String> existingTimeSeriesNames) {
         this.config = config;
         this.existingTimeSeriesNames = existingTimeSeriesNames;

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/ScriptTimeSeriesDslLoaderTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/ScriptTimeSeriesDslLoaderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.metrix.mapping;
+
+import com.powsybl.commons.test.TestUtil;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.metrix.commons.data.datatable.DataTableStore;
+import com.powsybl.metrix.mapping.config.ScriptLogConfig;
+import com.powsybl.timeseries.ReadOnlyTimeSeriesStore;
+import com.powsybl.timeseries.ReadOnlyTimeSeriesStoreCache;
+import com.powsybl.timeseries.RegularTimeSeriesIndex;
+import com.powsybl.timeseries.TimeSeries;
+import com.powsybl.timeseries.TimeSeriesIndex;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.threeten.extra.Interval;
+
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Marianne Funfrock {@literal <marianne.funfrock at rte-france.com>}
+ */
+class ScriptTimeSeriesDslLoaderTest {
+
+    private void launchTest(String script, String expectedTsNames) throws IOException {
+        Network network = Mockito.mock(Network.class);
+        MappingParameters parameters = Mockito.mock(MappingParameters.class);
+
+        TimeSeriesIndex index = RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-07-20T00:00:00Z"), Duration.ofDays(50));
+        ReadOnlyTimeSeriesStore store = new ReadOnlyTimeSeriesStoreCache(
+            TimeSeries.createDouble("ts", index, 1d, 2d, 3d, 4d, 5d)
+        );
+
+        // load mapping script
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (Writer out = new BufferedWriter(new OutputStreamWriter(outputStream))) {
+            new TimeSeriesDslLoader(script).load(network, parameters, store, new DataTableStore(), new ScriptLogConfig(out), null);
+        }
+
+        String output = TestUtil.normalizeLineSeparator(outputStream.toString());
+        assertEquals(expectedTsNames, output);
+    }
+
+    @Test
+    void testTsNames() throws IOException {
+        final String expectedTsNames = "inputTsNames = [ts]\ncalculatedTsNames = []\ncalculatedTsNames = [one]\ncalculatedTsNames = [one, two]\ninputTsNames = [ts]\n";
+
+        // mapping script
+        String script = """
+            println("inputTsNames = " + inputTsNames())
+            println("calculatedTsNames = " + calculatedTsNames())
+            ts['one'] = 1
+            println("calculatedTsNames = " + calculatedTsNames())
+            ts['two'] = 2
+            println("calculatedTsNames = " + calculatedTsNames())
+            println("inputTsNames = " + inputTsNames())
+            """;
+
+        launchTest(script, expectedTsNames);
+    }
+
+    @Test
+    void testTsExists() throws IOException {
+        final String expectedTsExists = "ts = true\none = false\none = false\none = true\n";
+
+        // mapping script
+        String script = """
+            println("ts = " + inputTsExists('ts'))
+            println("one = " + inputTsExists('one'))
+            println("one = " + calculatedTsExists('one'))
+            ts['one'] = 1
+            println("one = " + calculatedTsExists('one'))
+            """;
+
+        launchTest(script, expectedTsExists);
+    }
+}

--- a/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/ScriptTimeSeriesDslLoaderTest.java
+++ b/metrix-mapping/src/test/java/com/powsybl/metrix/mapping/ScriptTimeSeriesDslLoaderTest.java
@@ -17,6 +17,9 @@ import com.powsybl.timeseries.RegularTimeSeriesIndex;
 import com.powsybl.timeseries.TimeSeries;
 import com.powsybl.timeseries.TimeSeriesIndex;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.threeten.extra.Interval;
 
@@ -26,8 +29,10 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.time.Duration;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Marianne Funfrock {@literal <marianne.funfrock at rte-france.com>}
@@ -85,5 +90,45 @@ class ScriptTimeSeriesDslLoaderTest {
             """;
 
         launchTest(script, expectedTsExists);
+    }
+
+    @Test
+    void testAllTsNames() throws IOException {
+        final String expectedTsNames = "ts = true\none = false\ntsNames = [ts]\none = true\ntsNames = [ts, one]\n";
+
+        // mapping script
+        String script = """
+            println("ts = " + tsExists('ts'))
+            println("one = " + tsExists('one'))
+            println("tsNames = " + tsNames())
+            ts['one'] = 1
+            println("one = " + tsExists('one'))
+            println("tsNames = " + tsNames())
+            """;
+
+        launchTest(script, expectedTsNames);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideForbiddenModificationScript")
+    void testAddingNameInUnmodifiableInputTsNames(String script) {
+        assertThrows(UnsupportedOperationException.class, () -> launchTest(script, ""));
+    }
+
+    private static Stream<Arguments> provideForbiddenModificationScript() {
+        return Stream.of(
+            Arguments.of("""
+            timeSeriesNames = inputTsNames()
+            timeSeriesNames.add("otherTimeSeriesName")
+            """),
+            Arguments.of("""
+            timeSeriesNames = calculatedTsNames()
+            timeSeriesNames.add("otherTimeSeriesName")
+            """),
+            Arguments.of("""
+            timeSeriesNames = tsNames()
+            timeSeriesNames.add("otherTimeSeriesName")
+            """)
+        );
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
It is impossible to access existing calculated time series names in mapping script


**What is the new behavior (if this is a feature change)?**
Provide this access

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
