### PR TITLE
Refactor `getElementsToTrip` to remove duplicates

### DIFF
--- a/metrix-integration/src/main/java/com/powsybl/metrix/integration/network/MetrixNetwork.java
+++ b/metrix-integration/src/main/java/com/powsybl/metrix/integration/network/MetrixNetwork.java
@@ -860,15 +860,25 @@ public class MetrixNetwork {
                 terminalsToDisconnect.add(nodeBreakerView.getTerminal1(s.getId()));
                 terminalsToDisconnect.add(nodeBreakerView.getTerminal2(s.getId()));
             }
-            terminalsToDisconnect.stream()
-                .filter(Objects::nonNull)
-                .forEach(t -> {
-                    Connectable<?> connectable = t.getConnectable();
-                    if (connectable != null && types.contains(connectable.getType())) {
-                        elementsToTrip.add(new BranchContingency(connectable.getId()));
-                    }
-                });
+            addConnectableFromTerminalToDisconnectToElementsToTrip(terminalsToDisconnect, types, elementsToTrip);
         }
         return elementsToTrip;
+    }
+
+    private static void addConnectableFromTerminalToDisconnectToElementsToTrip(Set<Terminal> terminalsToDisconnect, Set<IdentifiableType> types, Set<ContingencyElement> elementsToTrip) {
+        Set<String> addedIds = elementsToTrip.stream()
+            .map(ContingencyElement::getId)
+            .collect(Collectors.toCollection(HashSet::new));
+        for (Terminal terminal : terminalsToDisconnect) {
+            if (terminal != null) {
+                Connectable<?> connectable = terminal.getConnectable();
+                if (connectable != null && types.contains(connectable.getType())) {
+                    String connectableId = connectable.getId();
+                    if (addedIds.add(connectableId)) {
+                        elementsToTrip.add(new BranchContingency(connectableId));
+                    }
+                }
+            }
+        }
     }
 }

--- a/metrix-integration/src/test/java/com/powsybl/metrix/integration/network/MetrixInputTest.java
+++ b/metrix-integration/src/test/java/com/powsybl/metrix/integration/network/MetrixInputTest.java
@@ -501,6 +501,19 @@ class MetrixInputTest {
     }
 
     @Test
+    void propagateTrippingNoDuplicatesTest() {
+        Network n = NetworkSerDe.read(Objects.requireNonNull(getClass().getResourceAsStream("/simpleNetwork_with_battery.xml")));
+
+        ContingencyElement l = new LineContingency("FP.AND1  FVERGE1  1");
+        Contingency cty = new Contingency("cty", l);
+
+        MetrixNetwork metrixNetwork = MetrixNetwork.create(n);
+        // As we
+        assertEquals(metrixNetwork.getElementsToTrip(cty, true), ImmutableSet.of(l));
+        assertEquals(metrixNetwork.getElementsToTrip(cty, false), ImmutableSet.of(l));
+    }
+
+    @Test
     void loadBreakTest() throws IOException {
         Network n = NetworkSerDe.read(Objects.requireNonNull(getClass().getResourceAsStream("/simpleNetwork_with_battery.xml")));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The getElementsToTrip() function returns a list of ContingencyElements, some of which have duplicate IDs
This occurs when a LineContingency is added as a BranchContingency in the input or when any combination of two different contingencyElement is used


**What is the new behavior (if this is a feature change)?**
The getElementsToTrip() function returns a list of ContingencyElements, all have unique ID


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
